### PR TITLE
fix: remove thread local from reader / writer

### DIFF
--- a/vec113/src/main/java/com/foursoft/vecmodel/vec113/VecReader.java
+++ b/vec113/src/main/java/com/foursoft/vecmodel/vec113/VecReader.java
@@ -31,23 +31,36 @@ import com.foursoft.xml.model.Identifiable;
 /**
  * A default implementation for a thread local stored VEC 113 reader. Validation events are logged to slf4j.
  * If a custom event consumer is needed, derive from  @{@link XMLReader}
+ * <p>
+ * In the past, this reader had a thread local singleton functionality in order to reuse
+ * the reader for repeated reads. This caused memory leaks in environments with thread
+ * pools (e.g. servlet container) as the JVM default {@link javax.xml.bind.Unmarshaller}
+ * implementation does not clean up internal states properly after unmarshalling is finished.
+ * Therefore the functionality has been dropped.
+ * </p>
+ * <p>
+ * The performance overhead of creating a new reader for each read is about 10% - 15% for
+ * repeated reads. The overhead is independent from the size of unmarshalled file. If this is an
+ * issue, you can manage your own singleton reader (it is <b>not thread-safe</b>, but can be reused).
+ * </p>
  */
 public final class VecReader extends XMLReader<VecContent, Identifiable> {
 
-    private static final ThreadLocal<VecReader> localReader = ThreadLocal.withInitial(VecReader::new);
-
-    /**
-     * The default constructor. Creating an un-marshaller takes a lot of time, it is advised to use a cached version.
-     * Jaxb is not thread safe, so an new marshaller must be created for every thread.
+        /**
+     * The default constructor.
      */
     public VecReader() {
         super(VecContent.class, Identifiable.class, Identifiable::getXmlId);
     }
 
     /**
-     * @return a thread local VecReader object
+     * @return a new VecReader for each call.
+     *
+     * @deprecated the thread local caching has been removed due to memory leaking issues. Create your
+     *    own {@link VecReader} and cache it by yourself if necessary. Will be removed with a future release.
      */
+    @Deprecated
     public static VecReader getLocalReader() {
-        return localReader.get();
+        return new VecReader();
     }
 }

--- a/vec113/src/main/java/com/foursoft/vecmodel/vec113/VecWriter.java
+++ b/vec113/src/main/java/com/foursoft/vecmodel/vec113/VecWriter.java
@@ -35,8 +35,7 @@ import java.util.function.Consumer;
  * a default implementation for a vec 113 writer
  */
 public final class VecWriter extends XMLWriter<VecContent> {
-    private static final ThreadLocal<VecWriter> localWriter = ThreadLocal.withInitial(
-            VecWriter::new);
+
 
     /**
      * create a default VecWriter with a default validation events logger {@link ValidationEventLogger}
@@ -55,9 +54,13 @@ public final class VecWriter extends XMLWriter<VecContent> {
     }
 
     /**
-     * @return a thread local VecWriter object
+     * @return a new VecWriter for each call.
+     *
+     * @deprecated the thread local caching has been removed due to memory leaking issues. Create your
+     *    own {@link VecWriter} and cache it by yourself if necessary. Will be removed with a future release.
      */
+    @Deprecated
     public static VecWriter getLocalWriter() {
-        return localWriter.get();
+        return new VecWriter();
     }
 }

--- a/vec120/src/main/java/com/foursoft/vecmodel/vec120/VecWriter.java
+++ b/vec120/src/main/java/com/foursoft/vecmodel/vec120/VecWriter.java
@@ -36,9 +36,6 @@ import java.util.function.Consumer;
  */
 public final class VecWriter extends XMLWriter<VecContent> {
 
-    private static final ThreadLocal<VecWriter> localWriter = ThreadLocal.withInitial(
-            VecWriter::new);
-
     /**
      * create a default VecWriter with a default validation events logger {@link ValidationEventLogger}
      */
@@ -56,9 +53,13 @@ public final class VecWriter extends XMLWriter<VecContent> {
     }
 
     /**
-     * @return a thread local VecWriter object
+     * @return a new VecWriter for each call.
+     *
+     * @deprecated the thread local caching has been removed due to memory leaking issues. Create your
+     *    own {@link VecWriter} and cache it by yourself if necessary. Will be removed with a future release.
      */
+    @Deprecated
     public static VecWriter getLocalWriter() {
-        return localWriter.get();
+        return new VecWriter();
     }
 }


### PR DESCRIPTION
## Pull Request

- [x] I have checked for similar PRs.
- [x] I have read the [contributing guidelines](https://github.com/4Soft-de/vec-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [x] Code
- [x] Documentation
- [ ] Other: 

### Description

ThreadLocal caching of reader / writer caused memory leaks and there has been dropped.