### PR TITLE
Adding default labels to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,7 @@
 ---
 name: Bug Report
 about: Found a bug that needs to be fixed?
+labels: "bug"
 ---
 
 ## General Troubleshooting

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,7 @@
 ---
 name: Feature Request
 about: Want to request a new feature for our VEC model?
+labels: "enhancement"
 ---
 
 ## General Troubleshooting

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,6 +1,7 @@
 ---
 name: Question
 about: Have a question regarding the VEC?
+labels: "question"
 ---
 
 ## General Troubleshooting


### PR DESCRIPTION
## Pull Request

- [x] I have checked for similar PRs.
- [x] I have read the [contributing guidelines](https://github.com/4Soft-de/vec-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [ ] Code
- [ ] Documentation
- [x] Other: Issue Templates

### Description

When creating an issue from a template, representative labels will be added to it after its creation now.