### PR TITLE
Add DependaBot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # Enable dependency updates for Maven
+  - package-ecosystem: "maven"
+    # Look for the pom.xml in the root folder
+    directory: "/"
+    schedule:
+      # Daily Updates (time can be set via. `time: "02:00"` under `interval`)
+      interval: "daily"
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      
+# Full reference: https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#configuration-options-for-dependabotyml


### PR DESCRIPTION
## Pull Request

- [x] I have checked for similar PRs.
- [x] I have read the [contributing guidelines](https://github.com/4Soft-de/vec-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [ ] Code
- [ ] Documentation
- [x] Other: GitHub

### Description

Adds DependaBot to keep Maven and GH Action dependencies up2date.

Further Resources:
- https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/
- https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#configuration-options-for-dependabotyml

**Perhaps important:**
Dependabot alerts or Dependabot security updates should be enabled.

> If you haven’t already enabled Dependabot alerts or Dependabot security updates, or want to check if they’re enabled, you can do it now by going to your repository’s Settings page. Click the new Security & analysis tab on the left, and then click Enable next to Dependabot alerts and Dependabot security updates.
![hi](https://github.blog/wp-content/uploads/2020/05/enable-automated-security-updates.gif?resize=1024%2C619)