### PR TITLE
extend the model to set the xml id and idenfication generically

### DIFF
--- a/vec-common/src/main/java/com/foursoft/vecmodel/common/HasModifiableIdentification.java
+++ b/vec-common/src/main/java/com/foursoft/vecmodel/common/HasModifiableIdentification.java
@@ -1,0 +1,31 @@
+/*-
+ * ========================LICENSE_START=================================
+ * vec-common
+ * %%
+ * Copyright (C) 2020 - 2021 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.vecmodel.common;
+
+public interface HasModifiableIdentification extends HasIdentification {
+
+    void setIdentification(String identification);
+}

--- a/vec113/src/main/resources/vec113/vec_1.1.3-ext.xjb
+++ b/vec113/src/main/resources/vec113/vec_1.1.3-ext.xjb
@@ -1,43 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jxb:bindings xmlns:jxb="http://java.sun.com/xml/ns/jaxb"
-    xmlns:xsi="http://www.w3.org/2000/10/XMLSchema-instance"
-    xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc" extensionBindingPrefixes="xjc dg"
-    xmlns:inheritance="http://jaxb2-commons.dev.java.net/basic/inheritance"
-    xmlns:ci="http://jaxb.dev.java.net/plugin/code-injector"
-    xmlns:dg="http://www.codesup.net/jaxb/plugins/delegate"
-    xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xhtml="http://www.w3.org/1999/xhtml"
-    xmlns:annox="http://annox.dev.java.net" jxb:extensionBindingPrefixes="xjc annox xhtml"
-    node="/xs:schema" schemaLocation="vec_1.1.3.xsd" version="2.1">
+        xmlns:inheritance="http://jaxb2-commons.dev.java.net/basic/inheritance"
+        xmlns:ci="http://jaxb.dev.java.net/plugin/code-injector"
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        extensionBindingPrefixes="xjc dg"
+        jxb:extensionBindingPrefixes="xjc annox xhtml"
+        node="/xs:schema" schemaLocation="vec_1.1.3.xsd" version="2.1">
 
 
     <jxb:bindings multiple="true" node="//xs:complexType[xs:attribute[@name='id']]">
         <inheritance:implements>com.foursoft.xml.model.Identifiable</inheritance:implements>
-        <ci:code> @Override public String toString() { return this.getClass().getSimpleName() + "["
-            + this.getXmlId() + "]"; } </ci:code>
+        <inheritance:implements>com.foursoft.xml.model.ModifiableIdentifiable</inheritance:implements>
+        <ci:code>@Override public String toString() { return this.getClass().getSimpleName() + "["
+            + this.getXmlId() + "]"; }
+        </ci:code>
     </jxb:bindings>
 
     <jxb:bindings node="//xs:attribute[@name='id']" multiple="true">
         <jxb:property name="xmlId"/>
     </jxb:bindings>
 
-     <jxb:bindings multiple="true" node="//xs:complexType[.//xs:element[@name='Identification']]">
-         <inheritance:implements>com.foursoft.vecmodel.common.HasIdentification</inheritance:implements>
-     </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[.//xs:element[@name='Identification']]">
+        <inheritance:implements>com.foursoft.vecmodel.common.HasIdentification</inheritance:implements>
+        <inheritance:implements>com.foursoft.vecmodel.common.HasModifiableIdentification</inheritance:implements>
+    </jxb:bindings>
 
-     <jxb:bindings multiple="true" node="//xs:complexType[.//xs:element[@name='Description' and @type='vec:AbstractLocalizedString']]">
-         <inheritance:implements>com.foursoft.vecmodel.common.HasDescription&lt;com.foursoft.vecmodel.vec113.VecAbstractLocalizedString&gt;</inheritance:implements>
-     </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[.//xs:element[@name='Description' and @type='vec:AbstractLocalizedString']]">
+        <inheritance:implements>com.foursoft.vecmodel.common.HasDescription&lt;com.foursoft.vecmodel.vec113.VecAbstractLocalizedString&gt;</inheritance:implements>
+    </jxb:bindings>
 
-     <jxb:bindings multiple="true" node="//xs:complexType[.//xs:element[@name='Description' and @type='vec:LocalizedString']]">
-          <inheritance:implements>com.foursoft.vecmodel.common.HasDescription&lt;com.foursoft.vecmodel.vec113.VecLocalizedString&gt;</inheritance:implements>
-     </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[.//xs:element[@name='Description' and @type='vec:LocalizedString']]">
+        <inheritance:implements>com.foursoft.vecmodel.common.HasDescription&lt;com.foursoft.vecmodel.vec113.VecLocalizedString&gt;</inheritance:implements>
+    </jxb:bindings>
 
     <jxb:bindings multiple="true" node="//xs:complexType[.//xs:element[@name='Specification' and @type='vec:Specification']]">
-       <inheritance:implements>com.foursoft.vecmodel.common.HasSpecifications&lt;com.foursoft.vecmodel.vec113.VecSpecification&gt;</inheritance:implements>
+        <inheritance:implements>com.foursoft.vecmodel.common.HasSpecifications&lt;com.foursoft.vecmodel.vec113.VecSpecification&gt;</inheritance:implements>
     </jxb:bindings>
 
     <jxb:bindings multiple="true" node="//xs:complexType[.//xs:element[@name='Role' and @type='vec:Role']]">
-       <inheritance:implements>com.foursoft.vecmodel.common.HasRoles&lt;com.foursoft.vecmodel.vec113.VecRole&gt;</inheritance:implements>
+        <inheritance:implements>com.foursoft.vecmodel.common.HasRoles&lt;com.foursoft.vecmodel.vec113.VecRole&gt;</inheritance:implements>
     </jxb:bindings>
 
 </jxb:bindings>

--- a/vec120/src/main/resources/vec120/vec_1.2.0-ext.xjb
+++ b/vec120/src/main/resources/vec120/vec_1.2.0-ext.xjb
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jxb:bindings xmlns:jxb="http://java.sun.com/xml/ns/jaxb"
-    xmlns:xsi="http://www.w3.org/2000/10/XMLSchema-instance"
-    xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc" extensionBindingPrefixes="xjc dg"
-    xmlns:inheritance="http://jaxb2-commons.dev.java.net/basic/inheritance"
-    xmlns:ci="http://jaxb.dev.java.net/plugin/code-injector"
-    xmlns:dg="http://www.codesup.net/jaxb/plugins/delegate"
-    xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xhtml="http://www.w3.org/1999/xhtml"
-    xmlns:annox="http://annox.dev.java.net" jxb:extensionBindingPrefixes="xjc annox xhtml"
-    node="/xs:schema" schemaLocation="vec_1.2.1.RC-SNAPSHOT.xsd" version="2.1">
+        xmlns:inheritance="http://jaxb2-commons.dev.java.net/basic/inheritance"
+        xmlns:ci="http://jaxb.dev.java.net/plugin/code-injector"
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        extensionBindingPrefixes="xjc dg"
+        jxb:extensionBindingPrefixes="xjc annox xhtml"
+        node="/xs:schema" schemaLocation="vec_1.2.1.RC-SNAPSHOT.xsd" version="2.1">
 
 
     <jxb:bindings multiple="true" node="//xs:complexType[xs:attribute[@name='id']]">
-		<inheritance:implements>com.foursoft.xml.model.Identifiable</inheritance:implements>
-		<ci:code> @Override public String toString() { return this.getClass().getSimpleName() + "["
-            + this.getXmlId() + "]"; } </ci:code>
+        <inheritance:implements>com.foursoft.xml.model.Identifiable</inheritance:implements>
+        <inheritance:implements>com.foursoft.xml.model.ModifiableIdentifiable</inheritance:implements>
+        <ci:code>@Override public String toString() { return this.getClass().getSimpleName() + "["
+            + this.getXmlId() + "]"; }
+        </ci:code>
     </jxb:bindings>
 
     <jxb:bindings node="//xs:attribute[@name='id']" multiple="true">
@@ -22,22 +22,23 @@
 
     <jxb:bindings multiple="true" node="//xs:complexType[.//xs:element[@name='Identification']]">
         <inheritance:implements>com.foursoft.vecmodel.common.HasIdentification</inheritance:implements>
+        <inheritance:implements>com.foursoft.vecmodel.common.HasModifiableIdentification</inheritance:implements>
     </jxb:bindings>
 
     <jxb:bindings multiple="true" node="//xs:complexType[.//xs:element[@name='Description' and @type='vec:AbstractLocalizedString']]">
         <inheritance:implements>com.foursoft.vecmodel.common.HasDescription&lt;com.foursoft.vecmodel.vec120.VecAbstractLocalizedString&gt;</inheritance:implements>
     </jxb:bindings>
 
-     <jxb:bindings multiple="true" node="//xs:complexType[.//xs:element[@name='Description' and @type='vec:LocalizedString']]">
-          <inheritance:implements>com.foursoft.vecmodel.common.HasDescription&lt;com.foursoft.vecmodel.vec120.VecLocalizedString&gt;</inheritance:implements>
-     </jxb:bindings>
+    <jxb:bindings multiple="true" node="//xs:complexType[.//xs:element[@name='Description' and @type='vec:LocalizedString']]">
+        <inheritance:implements>com.foursoft.vecmodel.common.HasDescription&lt;com.foursoft.vecmodel.vec120.VecLocalizedString&gt;</inheritance:implements>
+    </jxb:bindings>
 
     <jxb:bindings multiple="true" node="//xs:complexType[.//xs:element[@name='Specification' and @type='vec:Specification']]">
-       <inheritance:implements>com.foursoft.vecmodel.common.HasSpecifications&lt;com.foursoft.vecmodel.vec120.VecSpecification&gt;</inheritance:implements>
+        <inheritance:implements>com.foursoft.vecmodel.common.HasSpecifications&lt;com.foursoft.vecmodel.vec120.VecSpecification&gt;</inheritance:implements>
     </jxb:bindings>
 
     <jxb:bindings multiple="true" node="//xs:complexType[.//xs:element[@name='Role' and @type='vec:Role']]">
-       <inheritance:implements>com.foursoft.vecmodel.common.HasRoles&lt;com.foursoft.vecmodel.vec120.VecRole&gt;</inheritance:implements>
+        <inheritance:implements>com.foursoft.vecmodel.common.HasRoles&lt;com.foursoft.vecmodel.vec120.VecRole&gt;</inheritance:implements>
     </jxb:bindings>
 
 </jxb:bindings>


### PR DESCRIPTION
## Pull Request

- [x] I have checked for similar PRs.
- [x] I have read the [contributing guidelines](https://github.com/4Soft-de/vec-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [x] Code
- [ ] Documentation
- [ ] Other: 


### Description

extended the vec models to set the xmlid and identification generically