### PR TITLE
TopologyZoneSpecifiction now inherits from the Specification. (VEC 1.…

### DIFF
--- a/vec120/src/main/resources/vec120/vec_1.2.1.RC-SNAPSHOT.xsd
+++ b/vec120/src/main/resources/vec120/vec_1.2.1.RC-SNAPSHOT.xsd
@@ -9438,19 +9438,22 @@
             <p>Specification for the definition of TopologyZones.</p>
          </xs:documentation>
       </xs:annotation>
-      <xs:sequence>
-         <xs:element name="Zone"
-                     type="vec:TopologyZone"
-                     minOccurs="0"
-                     maxOccurs="unbounded">
-            <xs:annotation>
-               <xs:documentation xml:lang="en">
-                  <p>Specifies the<i>TopologyZones</i>that are part of the<i>TopologyZoneSpecification</i>.</p>
-               </xs:documentation>
-            </xs:annotation>
-         </xs:element>
-      </xs:sequence>
-      <xs:attribute name="id" type="xs:ID" use="required"/>
+      <xs:complexContent>
+       <xs:extension base="vec:Specification">
+          <xs:sequence>
+             <xs:element name="Zone"
+                         type="vec:TopologyZone"
+                         minOccurs="0"
+                         maxOccurs="unbounded">
+                <xs:annotation>
+                   <xs:documentation xml:lang="en">
+                      <p>Specifies the<i>TopologyZones</i>that are part of the<i>TopologyZoneSpecification</i>.</p>
+                   </xs:documentation>
+                </xs:annotation>
+             </xs:element>
+          </xs:sequence>
+       </xs:extension>
+      </xs:complexContent>
    </xs:complexType>
    <xs:complexType name="Transformation2D">
       <xs:annotation>


### PR DESCRIPTION
…2.0)

## Pull Request

- [x] I have checked for similar PRs.
- [x] I have read the [contributing guidelines](https://github.com/4Soft-de/vec-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [x] Code
- [ ] Documentation
- [ ] Other: 

Closes: \<Put down the issue number if available or remove that line>

### Description

TopologyZoneSpecifiction now inherits from the Specification. (VEC 1.2.0)