### PR TITLE
Removal of local VecReader / -Writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ More examples can be found in the examples of each module:
 public class MyVecReader {
     public void readVecFile(final String pathToFile) throws JAXBException, IOException  {
         try (final InputStream is = MyVecReader.class.getResourceAsStream(pathToFile)) {
-            final VecReader localReader = new VecReader();
-            final JaxbModel<VecContent, Identifiable> model = localReader.readModel(is);
+            final VecReader vecReader = new VecReader();
+            final JaxbModel<VecContent, Identifiable> model = vecReader.readModel(is);
     
             final VecApproval approval = model.getIdLookup()
                     .findById(VecApproval.class, "id_2014_0")
@@ -201,10 +201,10 @@ public class MyVecWriter {
         root.getDocumentVersions().add(documentVersion);
         root.getPartVersions().add(partVersion);
 
-        final VecWriter localWriter = new VecWriter();
+        final VecWriter vecWriter = new VecWriter();
 
         try (final FileOutputStream outputStream = new FileOutputStream(target)) {
-            localWriter.write(root, outputStream);
+            vecWriter.write(root, outputStream);
         }
     }
 }

--- a/vec113/src/examples/java/MyVecReader.java
+++ b/vec113/src/examples/java/MyVecReader.java
@@ -14,8 +14,8 @@ public class MyVecReader {
 
     public static void readVecFile(final String pathToFile) throws IOException {
         try (final InputStream is = MyVecReader.class.getResourceAsStream(pathToFile)) {
-            final VecReader localReader = new VecReader();
-            final JaxbModel<VecContent, Identifiable> model = localReader.readModel(is);
+            final VecReader vecReader = new VecReader();
+            final JaxbModel<VecContent, Identifiable> model = vecReader.readModel(is);
 
             final VecApproval approval = model.getIdLookup()
                     .findById(VecApproval.class, "id_2014_0")
@@ -33,9 +33,9 @@ public class MyVecReader {
 
     public static void readFullVecFile(final String pathToFile) throws IOException {
         try (final InputStream is = MyVecReader.class.getResourceAsStream(pathToFile)) {
-            final VecReader localReader = new VecReader();
+            final VecReader vecReader = new VecReader();
 
-            final VecContent rootElement = localReader.read(is);
+            final VecContent rootElement = vecReader.read(is);
 
             final String vecVersion = rootElement.getVecVersion();
             final String generatingSystemName = rootElement.getGeneratingSystemName();
@@ -169,8 +169,8 @@ public class MyVecReader {
 
     public static void getBackReferences(final String pathToFile) throws IOException {
         try (final InputStream is = MyVecReader.class.getResourceAsStream(pathToFile)) {
-            final VecReader localReader = VecReader.getLocalReader();
-            final JaxbModel<VecContent, Identifiable> model = localReader.readModel(is);
+            final VecReader vecReader = new VecReader();
+            final JaxbModel<VecContent, Identifiable> model = vecReader.readModel(is);
 
             final VecContent content = model.getRootElement();
 

--- a/vec113/src/examples/java/MyVecWriter.java
+++ b/vec113/src/examples/java/MyVecWriter.java
@@ -35,10 +35,10 @@ public class MyVecWriter {
         root.getDocumentVersions().add(documentVersion);
         root.getPartVersions().add(partVersion);
 
-        final VecWriter localWriter = new VecWriter();
+        final VecWriter vecWriter = new VecWriter();
 
         try (final FileOutputStream outputStream = new FileOutputStream(target)) {
-            localWriter.write(root, outputStream);
+            vecWriter.write(root, outputStream);
         }
     }
 }

--- a/vec113/src/main/java/com/foursoft/vecmodel/vec113/VecReader.java
+++ b/vec113/src/main/java/com/foursoft/vecmodel/vec113/VecReader.java
@@ -65,13 +65,4 @@ public final class VecReader extends XMLReader<VecContent, Identifiable> {
         super(VecContent.class, Identifiable.class, Identifiable::getXmlId, validationEventConsumer);
     }
 
-    /**
-     * @return a new VecReader for each call.
-     * @deprecated the thread local caching has been removed due to memory leaking issues. Create your
-     * own {@link VecReader} and cache it by yourself if necessary. Will be removed with a future release.
-     */
-    @Deprecated
-    public static VecReader getLocalReader() {
-        return new VecReader();
-    }
 }

--- a/vec113/src/main/java/com/foursoft/vecmodel/vec113/VecWriter.java
+++ b/vec113/src/main/java/com/foursoft/vecmodel/vec113/VecWriter.java
@@ -53,14 +53,4 @@ public final class VecWriter extends XMLWriter<VecContent> {
         super(VecContent.class, validationEventConsumer);
     }
 
-    /**
-     * @return a new VecWriter for each call.
-     *
-     * @deprecated the thread local caching has been removed due to memory leaking issues. Create your
-     *    own {@link VecWriter} and cache it by yourself if necessary. Will be removed with a future release.
-     */
-    @Deprecated
-    public static VecWriter getLocalWriter() {
-        return new VecWriter();
-    }
 }

--- a/vec113/src/test/java/com/foursoft/vecmodel/vec113/BasicLoadingTest.java
+++ b/vec113/src/test/java/com/foursoft/vecmodel/vec113/BasicLoadingTest.java
@@ -148,17 +148,4 @@ class BasicLoadingTest {
         }
     }
 
-    @Test
-    void testGetLocalWriter() {
-        final VecReader localReader = VecReader.getLocalReader();
-        assertThat(localReader).isNotNull();
-    }
-
-    @Test
-    void testWithLocalReader() throws IOException {
-        try (final InputStream inputStream = TestFiles.getInputStream(TestFiles.SAMPLE_VEC)) {
-            final VecContent content = VecReader.getLocalReader().read(inputStream);
-            assertThat(content).isNotNull();
-        }
-    }
 }

--- a/vec113/src/test/java/com/foursoft/vecmodel/vec113/BasicWritingTest.java
+++ b/vec113/src/test/java/com/foursoft/vecmodel/vec113/BasicWritingTest.java
@@ -25,17 +25,11 @@
  */
 package com.foursoft.vecmodel.vec113;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class BasicWritingTest {
-    @Test
-    void testGetLocalWriter() {
-        final VecWriter localWriter = VecWriter.getLocalWriter();
-        Assertions.assertNotNull(localWriter);
-    }
 
     @Test
     void testWriteModel() {

--- a/vec120/src/examples/java/MyVecReader.java
+++ b/vec120/src/examples/java/MyVecReader.java
@@ -14,8 +14,8 @@ public class MyVecReader {
 
     public static void readVecFile(final String pathToFile) throws IOException {
         try (final InputStream is = MyVecReader.class.getResourceAsStream(pathToFile)) {
-            final VecReader localReader = VecReader.getLocalReader();
-            final JaxbModel<VecContent, Identifiable> model = localReader.readModel(is);
+            final VecReader vecReader = new VecReader();
+            final JaxbModel<VecContent, Identifiable> model = vecReader.readModel(is);
 
             final VecApproval approval = model.getIdLookup()
                     .findById(VecApproval.class, "id_2014_0")
@@ -33,9 +33,9 @@ public class MyVecReader {
 
     public static void readFullVecFile(final String pathToFile) throws IOException {
         try (final InputStream is = MyVecReader.class.getResourceAsStream(pathToFile)) {
-            final VecReader localReader = VecReader.getLocalReader();
+            final VecReader vecReader = new VecReader();
 
-            final VecContent rootElement = localReader.read(is);
+            final VecContent rootElement = vecReader.read(is);
 
             final String vecVersion = rootElement.getVecVersion();
             final String generatingSystemName = rootElement.getGeneratingSystemName();
@@ -161,8 +161,8 @@ public class MyVecReader {
 
     public static void getBackReferences(final String pathToFile) throws IOException {
         try (final InputStream is = MyVecReader.class.getResourceAsStream(pathToFile)) {
-            final VecReader localReader = VecReader.getLocalReader();
-            final JaxbModel<VecContent, Identifiable> model = localReader.readModel(is);
+            final VecReader vecReader = new VecReader();
+            final JaxbModel<VecContent, Identifiable> model = vecReader.readModel(is);
 
             final VecContent content = model.getRootElement();
 

--- a/vec120/src/examples/java/MyVecWriter.java
+++ b/vec120/src/examples/java/MyVecWriter.java
@@ -35,10 +35,10 @@ public class MyVecWriter {
         root.getDocumentVersions().add(documentVersion);
         root.getPartVersions().add(partVersion);
 
-        final VecWriter localWriter = VecWriter.getLocalWriter();
+        final VecWriter vecWriter = new VecWriter();
 
         try (final FileOutputStream outputStream = new FileOutputStream(target)) {
-            localWriter.write(root, outputStream);
+            vecWriter.write(root, outputStream);
         }
     }
 }

--- a/vec120/src/main/java/com/foursoft/vecmodel/vec120/VecReader.java
+++ b/vec120/src/main/java/com/foursoft/vecmodel/vec120/VecReader.java
@@ -65,13 +65,4 @@ public final class VecReader extends XMLReader<VecContent, Identifiable> {
         super(VecContent.class, Identifiable.class, Identifiable::getXmlId, validationEventConsumer);
     }
 
-    /**
-     * @return a new VecReader for each call.
-     * @deprecated the thread local caching has been removed due to memory leaking issues. Create your
-     * own {@link VecReader} and cache it by yourself if necessary. Will be removed with a future release.
-     */
-    @Deprecated
-    public static VecReader getLocalReader() {
-        return new VecReader();
-    }
 }

--- a/vec120/src/main/java/com/foursoft/vecmodel/vec120/VecWriter.java
+++ b/vec120/src/main/java/com/foursoft/vecmodel/vec120/VecWriter.java
@@ -52,14 +52,4 @@ public final class VecWriter extends XMLWriter<VecContent> {
         super(VecContent.class, validationEventConsumer);
     }
 
-    /**
-     * @return a new VecWriter for each call.
-     *
-     * @deprecated the thread local caching has been removed due to memory leaking issues. Create your
-     *    own {@link VecWriter} and cache it by yourself if necessary. Will be removed with a future release.
-     */
-    @Deprecated
-    public static VecWriter getLocalWriter() {
-        return new VecWriter();
-    }
 }

--- a/vec120/src/test/java/com/foursoft/vecmodel/vec120/BasicLoadingTest.java
+++ b/vec120/src/test/java/com/foursoft/vecmodel/vec120/BasicLoadingTest.java
@@ -148,17 +148,4 @@ class BasicLoadingTest {
         }
     }
 
-    @Test
-    void testGetLocalWriter() {
-        final VecReader localReader = VecReader.getLocalReader();
-        assertThat(localReader).isNotNull();
-    }
-
-    @Test
-    void testWithLocalReader() throws IOException {
-        try (final InputStream inputStream = TestFiles.getInputStream(TestFiles.SAMPLE_VEC)) {
-            final VecContent content = VecReader.getLocalReader().read(inputStream);
-            assertThat(content).isNotNull();
-        }
-    }
 }

--- a/vec120/src/test/java/com/foursoft/vecmodel/vec120/BasicWritingTest.java
+++ b/vec120/src/test/java/com/foursoft/vecmodel/vec120/BasicWritingTest.java
@@ -25,18 +25,11 @@
  */
 package com.foursoft.vecmodel.vec120;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class BasicWritingTest {
-
-    @Test
-    void testGetLocalWriter() {
-        final VecWriter localWriter = VecWriter.getLocalWriter();
-        Assertions.assertNotNull(localWriter);
-    }
 
     @Test
     void testWriteModel() {


### PR DESCRIPTION
## Pull Requesthttps://github.com/4Soft-de/vec-model/pull/64/files

- [x] I have checked for similar PRs.
- [x] I have read the [contributing guidelines](https://github.com/4Soft-de/vec-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [x] Code
- [ ] Documentation
- [ ] Other: 

### Description

Finally removed `getLocalReader` and `getLocalWriter` which have been deprecated with version v1.2.1. including tests for them. Also removed occurrences from the example files.