### PR TITLE
Made example code in the ReadMe more readable and added Ids to the Example Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,15 +234,16 @@ public class MyVecWriter {
 </vec:VecContent>
 ```
 ### Assertions on VEC files
-For each VEC version we provide an additional jar file with generated AssertJ assertions to write fluent assertions on VEC elements. The assertions are generated with the [AssertJ assertions generator](https://joel-costigliola.github.io/assertj/assertj-assertions-generator-maven-plugin.html). 
+For each VEC version we provide an additional jar file with generated AssertJ assertions to write fluent assertions on VEC elements.
+The assertions are generated with the [AssertJ assertions generator](https://joel-costigliola.github.io/assertj/assertj-assertions-generator-maven-plugin.html). 
 
-Below is a short example for the usage of these assertions in combination with native AssertJ-Assertions. For detailed information please refer to the original [AssertJ Documentation](https://assertj.github.io/doc/).
+Below is a short example for the usage of these assertions in combination with native AssertJ-Assertions.
+For detailed information please refer to the original [AssertJ Documentation](https://assertj.github.io/doc/).
 
-Please not the static imports of the [assertions entry point](https://joel-costigliola.github.io/assertj/assertj-core-custom-assertions.html) and the order of `...Assertions.assertThat;`.
+Please note the static imports of the [assertions entry point](https://joel-costigliola.github.io/assertj/assertj-core-custom-assertions.html)
+and the order of `...Assertions.assertThat;`.
 
 ```java
-package com.foursoft.vec.test;
-
 import static com.foursoft.vecmodel.vec113.assertions.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.atIndex;
@@ -253,23 +254,24 @@ import com.foursoft.vecmodel.vec113.VecConnectorHousingSpecification;
 import com.foursoft.vecmodel.vec113.VecDocumentVersion;
 import com.foursoft.vecmodel.vec113.VecPartVersion;
 
+class VecSampleTest {
 
-public class VecSampleTest {
+    @Test
+    void doSomeAssertions() {
+        //Find the element to test, maybe with a traversing visitor...
+        VecDocumentVersion partMasterDocument = null; // determine document version
 
-	@Test
-	void doSomeAssertions() {
-		//Find the element to test, maybe with a traversing visitor...
-		VecDocumentVersion partMasterDocument = null; // determine document version
-		
-		assertThat(partMasterDocument).hasDocumentType("PartMaster")
-				.hasNoCustomProperties()
-				.satisfies(d -> {
-					assertThat(d.getSpecificationsWithType(VecConnectorHousingSpecification.class)).hasSize(1)
-							.satisfies(chs -> {
-								assertThat(chs).hasIdentification("ABC");
-							}, atIndex(0));
-				});
-	}
+        assertThat(partMasterDocument)
+            .hasDocumentType("PartMaster")
+            .hasNoCustomProperties()
+            .satisfies(d ->
+                assertThat(d.getSpecificationsWithType(VecConnectorHousingSpecification.class))
+                    .hasSize(1)
+                    .satisfies(
+                         chs -> assertThat(chs).hasIdentification("ABC"), 
+                         atIndex(0))
+            );
+    }
 }
 
 ```

--- a/vec113/src/examples/java/MyVecWriter.java
+++ b/vec113/src/examples/java/MyVecWriter.java
@@ -5,20 +5,22 @@ import java.io.IOException;
 
 public class MyVecWriter {
 
-    public static void writeVecFile(final String target) throws IOException {
-
+    public static void writeExampleVecFile(final String target) throws IOException {
         final VecContent root = new VecContent();
         root.setXmlId("id_1000_0");
         root.setVecVersion("1.1.3");
 
         final VecPermission permission = new VecPermission();
+        permission.setXmlId("id_2185_0");
         permission.setPermission("Released");
 
         final VecApproval approval = new VecApproval();
+        approval.setXmlId("id_2014_0");
         approval.setStatus("Approved");
         approval.getPermissions().add(permission);
 
         final VecDocumentVersion documentVersion = new VecDocumentVersion();
+        documentVersion.setXmlId("id_1002_0");
         documentVersion.getApprovals().add(approval);
         documentVersion.setDocumentNumber("123_456_789");
 

--- a/vec120/src/examples/java/MyVecWriter.java
+++ b/vec120/src/examples/java/MyVecWriter.java
@@ -5,20 +5,22 @@ import java.io.IOException;
 
 public class MyVecWriter {
 
-    public static void writeVecFile(final String target) throws IOException {
-
+    public static void writeExampleVecFile(final String target) throws IOException {
         final VecContent root = new VecContent();
         root.setXmlId("id_1000_0");
         root.setVecVersion("1.1.3");
 
         final VecPermission permission = new VecPermission();
+        permission.setXmlId("id_2185_0");
         permission.setPermission("Released");
 
         final VecApproval approval = new VecApproval();
+        approval.setXmlId("id_2014_0");
         approval.setStatus("Approved");
         approval.getPermissions().add(permission);
 
         final VecDocumentVersion documentVersion = new VecDocumentVersion();
+        documentVersion.setXmlId("id_1002_0");
         documentVersion.getApprovals().add(approval);
         documentVersion.setDocumentNumber("123_456_789");
 


### PR DESCRIPTION
## Pull Request

- [x] I have checked for similar PRs.
- [x] I have read the [contributing guidelines](https://github.com/4Soft-de/vec-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [ ] Code
- [ ] Documentation
- [x] Other: Beautify and Example Files

### Description

The assertion code example used tabs which makes it hard(er) to read it. Used spaces instead and slightly reformatted the code to be more readable.

Also added xml ids to example files which I forgot in #62.