### PR TITLE
Fix test case by using own SchemaFactory

### DIFF
--- a/vec113/src/test/java/com/foursoft/vecmodel/vec113/BasicLoadingTest.java
+++ b/vec113/src/test/java/com/foursoft/vecmodel/vec113/BasicLoadingTest.java
@@ -39,7 +39,6 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
-import javax.xml.validation.SchemaFactory;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -101,11 +100,7 @@ class BasicLoadingTest {
     @Test
     void validationTest() throws Exception {
         try (final InputStream is = TestFiles.getInputStream(TestFiles.SAMPLE_VEC)) {
-            final SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-
-            final Source source = new StreamSource(getClass().getResourceAsStream("/vec113/vec_1.1.3.xsd"));
-
-            final Schema schema = schemaFactory.newSchema(source);
+            final Schema schema = SchemaFactory.getSchema();
 
             final DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 

--- a/vec120/src/test/java/com/foursoft/vecmodel/vec120/BasicLoadingTest.java
+++ b/vec120/src/test/java/com/foursoft/vecmodel/vec120/BasicLoadingTest.java
@@ -39,7 +39,6 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
-import javax.xml.validation.SchemaFactory;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -101,11 +100,7 @@ class BasicLoadingTest {
     @Test
     void validationTest() throws Exception {
         try (final InputStream is = TestFiles.getInputStream(TestFiles.SAMPLE_VEC)) {
-            final SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-
-            final Source source = new StreamSource(getClass().getResourceAsStream("/vec120/vec_1.2.0-strict.xsd"));
-
-            final Schema schema = schemaFactory.newSchema(source);
+            final Schema schema = SchemaFactory.getStrictSchema();
 
             final DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 


### PR DESCRIPTION
## Pull Request

- [x] I have checked for similar PRs.
- [x] I have read the [contributing guidelines](https://github.com/4Soft-de/vec-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [x] Code
- [ ] Documentation
- [ ] Other: 

### Description

Contains a commit from PR #59 which will not be merged due to being outdated. This commit makes use of your own SchemaFactory which makes it easier to get the (strict) XSD. This also uses the variables for the (strict) XSDs so there won't be a problem anymore when changing the XSDs like done with #66.