### PR TITLE
Navigation methods for VEC 1.2.0

### DIFF
--- a/vec-common/src/main/java/com/foursoft/vecmodel/common/annotations/RequiresBackReferences.java
+++ b/vec-common/src/main/java/com/foursoft/vecmodel/common/annotations/RequiresBackReferences.java
@@ -1,0 +1,43 @@
+/*-
+ * ========================LICENSE_START=================================
+ * vec-common
+ * %%
+ * Copyright (C) 2020 - 2022 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.vecmodel.common.annotations;
+
+import java.lang.annotation.*;
+
+/**
+ * If a method is annotated with this annotation it means that it uses the back references feature of the VEC model.
+ * <p>
+ * Back references are only set for {@code VecContent}s which have been read / imported, <b>not
+ * for manually created VecContents</b>. If the annotated method is used on a VecContent without back references, then
+ * exceptions ({@link NullPointerException}s) are likely to be raised.
+ * <p>
+ * Export and re-import a manually created VecContent to use that method.
+ */
+@Documented
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RequiresBackReferences {
+}

--- a/vec120/src/main/java/com/foursoft/vecmodel/vec120/navigations/ConfigurableElementNavs.java
+++ b/vec120/src/main/java/com/foursoft/vecmodel/vec120/navigations/ConfigurableElementNavs.java
@@ -1,0 +1,60 @@
+/*-
+ * ========================LICENSE_START=================================
+ * vec120
+ * %%
+ * Copyright (C) 2020 - 2022 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.vecmodel.vec120.navigations;
+
+import com.foursoft.vecmodel.vec120.VecConfigurableElement;
+import com.foursoft.vecmodel.vec120.VecVariantConfiguration;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Navigation methods for the {@link VecConfigurableElement}.
+ */
+public final class ConfigurableElementNavs {
+
+    private ConfigurableElementNavs() {
+        // hide default constructor
+    }
+
+    public static Function<VecConfigurableElement, Optional<VecVariantConfiguration>> variantConfiguration() {
+        return configurableElement -> Optional.ofNullable(configurableElement)
+                .map(VecConfigurableElement::getConfigInfo);
+    }
+
+    public static Function<VecConfigurableElement, Optional<String>> controlInformation() {
+        return configurableElement -> Optional.ofNullable(configurableElement)
+                .map(VecConfigurableElement::getConfigInfo)
+                .map(VecVariantConfiguration::getLogisticControlString);
+    }
+
+    public static Function<VecConfigurableElement, Optional<String>> controlExpression() {
+        return configurableElement -> Optional.ofNullable(configurableElement)
+                .map(VecConfigurableElement::getConfigInfo)
+                .map(VecVariantConfiguration::getLogisticControlExpression);
+    }
+
+}

--- a/vec120/src/main/java/com/foursoft/vecmodel/vec120/navigations/ContentNavs.java
+++ b/vec120/src/main/java/com/foursoft/vecmodel/vec120/navigations/ContentNavs.java
@@ -28,14 +28,12 @@ package com.foursoft.vecmodel.vec120.navigations;
 import com.foursoft.vecmodel.vec120.VecContent;
 import com.foursoft.vecmodel.vec120.VecDocumentVersion;
 import com.foursoft.vecmodel.vec120.VecSpecification;
-import com.foursoft.vecmodel.vec120.VecUnit;
 import com.foursoft.vecmodel.vec120.utils.StreamUtils;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Navigation methods for the {@link VecContent}.
@@ -58,11 +56,6 @@ public final class ContentNavs {
         return content -> content.getDocumentVersions().stream()
                 .filter(documentVersion -> documentVersion.getDocumentNumber().equals(documentNumber))
                 .collect(StreamUtils.findOneOrNone());
-    }
-
-    // TODO Do this similar to HasRoles#getRolesWithType
-    public static <T extends VecUnit> Function<VecContent, Stream<T>> allUnitsOf(final Class<T> clazz) {
-        return content -> StreamUtils.checkAndCast(content.getUnits(), clazz);
     }
 
 }

--- a/vec120/src/main/java/com/foursoft/vecmodel/vec120/navigations/ContentNavs.java
+++ b/vec120/src/main/java/com/foursoft/vecmodel/vec120/navigations/ContentNavs.java
@@ -1,0 +1,68 @@
+/*-
+ * ========================LICENSE_START=================================
+ * vec120
+ * %%
+ * Copyright (C) 2020 - 2022 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.vecmodel.vec120.navigations;
+
+import com.foursoft.vecmodel.vec120.VecContent;
+import com.foursoft.vecmodel.vec120.VecDocumentVersion;
+import com.foursoft.vecmodel.vec120.VecSpecification;
+import com.foursoft.vecmodel.vec120.VecUnit;
+import com.foursoft.vecmodel.vec120.utils.StreamUtils;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Navigation methods for the {@link VecContent}.
+ */
+public final class ContentNavs {
+
+    private ContentNavs() {
+        // hide default constructor
+    }
+
+    public static <T extends VecSpecification> Function<VecContent, List<T>> allSpecificationsOf(final Class<T> clazz) {
+        return vecContent -> vecContent.getDocumentVersions()
+                .stream()
+                .flatMap(StreamUtils.toStream(dv -> dv.getSpecificationsWithType(clazz)))
+                .collect(Collectors.toList());
+    }
+
+    public static Function<VecContent, Optional<VecDocumentVersion>> documentVersionBy(
+            final String documentNumber) {
+        return content -> content.getDocumentVersions().stream()
+                .filter(documentVersion -> documentVersion.getDocumentNumber().equals(documentNumber))
+                .collect(StreamUtils.findOneOrNone());
+    }
+
+    // TODO Do this similar to HasRoles#getRolesWithType
+    public static <T extends VecUnit> Function<VecContent, Stream<T>> allUnitsOf(final Class<T> clazz) {
+        return content -> StreamUtils.checkAndCast(content.getUnits(), clazz);
+    }
+
+}

--- a/vec120/src/main/java/com/foursoft/vecmodel/vec120/navigations/CustomPropertyNavs.java
+++ b/vec120/src/main/java/com/foursoft/vecmodel/vec120/navigations/CustomPropertyNavs.java
@@ -1,0 +1,98 @@
+/*-
+ * ========================LICENSE_START=================================
+ * vec120
+ * %%
+ * Copyright (C) 2020 - 2022 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.vecmodel.vec120.navigations;
+
+import com.foursoft.vecmodel.vec120.*;
+import com.foursoft.vecmodel.vec120.utils.StreamUtils;
+
+import java.math.BigInteger;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Navigation methods for custom properties of a {@link VecExtendableElement}.
+ */
+public final class CustomPropertyNavs {
+
+    private CustomPropertyNavs() {
+        // hide default constructor
+    }
+
+    public static Function<VecExtendableElement, Optional<String>> customPropertyValueStringOf(
+            final String customProperty) {
+        return customPropertyValueOf(customProperty, VecSimpleValueProperty.class, VecSimpleValueProperty::getValue);
+    }
+
+    public static Function<VecExtendableElement, Optional<BigInteger>> customPropertyValueIntegerOf(
+            final String customProperty) {
+        return customPropertyValueOf(customProperty, VecIntegerValueProperty.class, VecIntegerValueProperty::getValue);
+    }
+
+    public static Function<VecExtendableElement, List<String>> customPropertyValueStringsOf(
+            final String customProperty) {
+        return customPropertyValuesOf(customProperty, VecSimpleValueProperty.class, VecSimpleValueProperty::getValue);
+    }
+
+    public static Function<VecExtendableElement, Optional<Double>> customPropertyValueDoubleOf(
+            final String customProperty) {
+        return customPropertyValueOf(customProperty, VecDoubleValueProperty.class, VecDoubleValueProperty::getValue);
+    }
+
+    public static Function<VecExtendableElement, Optional<VecValueRange>> customPropertyValueRangeOf(
+            final String customProperty) {
+        return customPropertyValueOf(customProperty, VecValueRangeProperty.class, VecValueRangeProperty::getValue);
+    }
+
+    public static Function<VecExtendableElement, Optional<Boolean>> customPropertyValueBooleanOf(
+            final String customProperty) {
+        return customPropertyValueOf(customProperty, VecBooleanValueProperty.class, VecBooleanValueProperty::isValue);
+    }
+
+    private static <P extends VecCustomProperty, T> Function<VecExtendableElement, Optional<T>> customPropertyValueOf(
+            final String customProperty, final Class<P> targetClass, final Function<P, T> converter) {
+        return element -> customPropertyValuesOf(customProperty, targetClass, converter)
+                .apply(element)
+                .stream()
+                .collect(StreamUtils.findOneOrNone());
+    }
+
+    private static <P extends VecCustomProperty, T> Function<VecExtendableElement, List<T>> customPropertyValuesOf(
+            final String customProperty, final Class<P> targetClass, final Function<P, T> converter) {
+        return element -> element == null
+                ? Collections.emptyList()
+                :
+                element.getCustomProperties()
+                        .stream()
+                        .flatMap(StreamUtils.ofClass(targetClass))
+                        .filter(property -> property.getPropertyType().equals(customProperty))
+                        .map(converter)
+                        .collect(Collectors.toList());
+    }
+
+}

--- a/vec120/src/main/java/com/foursoft/vecmodel/vec120/navigations/DescriptionNavs.java
+++ b/vec120/src/main/java/com/foursoft/vecmodel/vec120/navigations/DescriptionNavs.java
@@ -46,31 +46,31 @@ public final class DescriptionNavs {
         // hide default constructor
     }
 
-    public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> germanLanguageStringByDescription() {
-        return languageStringByDescription(VecLanguageCode.DE);
+    public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> germanDescription() {
+        return descriptionIn(VecLanguageCode.DE);
     }
 
-    public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> englishLanguageStringByDescription() {
-        return languageStringByDescription(VecLanguageCode.EN);
+    public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> englishDescription() {
+        return descriptionIn(VecLanguageCode.EN);
     }
 
-    public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> languageStringByDescription(
+    public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> descriptionIn(
             final VecLanguageCode vecLanguageCode) {
         return descHolder -> {
             final List<? extends VecAbstractLocalizedString> localizedStrings = descHolder.getDescriptions();
-            return languageString(vecLanguageCode).apply(localizedStrings);
+            return languageStringIn(vecLanguageCode).apply(localizedStrings);
         };
     }
 
     public static Function<List<? extends VecAbstractLocalizedString>, Optional<String>> germanLanguageString() {
-        return languageString(VecLanguageCode.DE);
+        return languageStringIn(VecLanguageCode.DE);
     }
 
     public static Function<List<? extends VecAbstractLocalizedString>, Optional<String>> englishLanguageString() {
-        return languageString(VecLanguageCode.EN);
+        return languageStringIn(VecLanguageCode.EN);
     }
 
-    public static Function<List<? extends VecAbstractLocalizedString>, Optional<String>> languageString(
+    public static Function<List<? extends VecAbstractLocalizedString>, Optional<String>> languageStringIn(
             final VecLanguageCode vecLanguageCode) {
         return localizedStrings -> {
             if (localizedStrings.isEmpty()) {
@@ -93,17 +93,17 @@ public final class DescriptionNavs {
         };
     }
 
-    public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> germanTypedLanguageString(
+    public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> germanTypedLanguageStringBy(
             final String descriptionType) {
-        return typedLanguageString(descriptionType, VecLanguageCode.DE);
+        return typedLanguageStringBy(descriptionType, VecLanguageCode.DE);
     }
 
-    public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> englishTypedLanguageString(
+    public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> englishTypedLanguageStringBy(
             final String descriptionType) {
-        return typedLanguageString(descriptionType, VecLanguageCode.EN);
+        return typedLanguageStringBy(descriptionType, VecLanguageCode.EN);
     }
 
-    public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> typedLanguageString(
+    public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> typedLanguageStringBy(
             final String descriptionType, final VecLanguageCode vecLanguageCode) {
         return hasDescription -> hasDescription.getDescriptions().stream()
                 .filter(VecPredicates.isLanguageCode(vecLanguageCode))

--- a/vec120/src/main/java/com/foursoft/vecmodel/vec120/navigations/DescriptionNavs.java
+++ b/vec120/src/main/java/com/foursoft/vecmodel/vec120/navigations/DescriptionNavs.java
@@ -1,0 +1,117 @@
+/*-
+ * ========================LICENSE_START=================================
+ * vec120
+ * %%
+ * Copyright (C) 2020 - 2022 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.vecmodel.vec120.navigations;
+
+import com.foursoft.vecmodel.common.HasDescription;
+import com.foursoft.vecmodel.vec120.VecAbstractLocalizedString;
+import com.foursoft.vecmodel.vec120.VecLanguageCode;
+import com.foursoft.vecmodel.vec120.VecLocalizedTypedString;
+import com.foursoft.vecmodel.vec120.predicates.VecPredicates;
+import com.foursoft.vecmodel.vec120.utils.StreamUtils;
+import com.foursoft.vecmodel.vec120.utils.StringUtils;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Navigation methods for {@link HasDescription} with {@link VecAbstractLocalizedString}s.
+ */
+public final class DescriptionNavs {
+
+    private DescriptionNavs() {
+        // hide default constructor
+    }
+
+    public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> germanLanguageStringByDescription() {
+        return languageStringByDescription(VecLanguageCode.DE);
+    }
+
+    public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> englishLanguageStringByDescription() {
+        return languageStringByDescription(VecLanguageCode.EN);
+    }
+
+    public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> languageStringByDescription(
+            final VecLanguageCode vecLanguageCode) {
+        return descHolder -> {
+            final List<? extends VecAbstractLocalizedString> localizedStrings = descHolder.getDescriptions();
+            return languageString(vecLanguageCode).apply(localizedStrings);
+        };
+    }
+
+    public static Function<List<? extends VecAbstractLocalizedString>, Optional<String>> germanLanguageString() {
+        return languageString(VecLanguageCode.DE);
+    }
+
+    public static Function<List<? extends VecAbstractLocalizedString>, Optional<String>> englishLanguageString() {
+        return languageString(VecLanguageCode.EN);
+    }
+
+    public static Function<List<? extends VecAbstractLocalizedString>, Optional<String>> languageString(
+            final VecLanguageCode vecLanguageCode) {
+        return localizedStrings -> {
+            if (localizedStrings.isEmpty()) {
+                return Optional.empty();
+            }
+            if (localizedStrings.size() == 1) {
+                final VecAbstractLocalizedString localizedString = localizedStrings.get(0);
+                if (localizedString instanceof VecLocalizedTypedString &&
+                        !StringUtils.isEmpty(((VecLocalizedTypedString) localizedString).getType())) {
+                    return Optional.empty();
+                }
+                return Optional.of(localizedString.getValue());
+            }
+
+            return localizedStrings.stream()
+                    .filter(d -> !(d instanceof VecLocalizedTypedString))
+                    .filter(VecPredicates.isLanguageCode(vecLanguageCode))
+                    .map(VecAbstractLocalizedString::getValue)
+                    .collect(StreamUtils.findOneOrNone());
+        };
+    }
+
+    public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> germanTypedLanguageString(
+            final String descriptionType) {
+        return typedLanguageString(descriptionType, VecLanguageCode.DE);
+    }
+
+    public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> englishTypedLanguageString(
+            final String descriptionType) {
+        return typedLanguageString(descriptionType, VecLanguageCode.EN);
+    }
+
+    public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> typedLanguageString(
+            final String descriptionType, final VecLanguageCode vecLanguageCode) {
+        return hasDescription -> hasDescription.getDescriptions().stream()
+                .filter(VecPredicates.isLanguageCode(vecLanguageCode))
+                .flatMap(StreamUtils.ofClass(VecLocalizedTypedString.class))
+                .filter(dv -> descriptionType.equals(dv.getType()))
+                .collect(StreamUtils.findOneOrNone())
+                .map(VecLocalizedTypedString::getValue)
+                .filter(StringUtils::isNotEmpty);
+    }
+
+}

--- a/vec120/src/main/java/com/foursoft/vecmodel/vec120/navigations/DescriptionNavs.java
+++ b/vec120/src/main/java/com/foursoft/vecmodel/vec120/navigations/DescriptionNavs.java
@@ -58,19 +58,19 @@ public final class DescriptionNavs {
             final VecLanguageCode vecLanguageCode) {
         return descHolder -> {
             final List<? extends VecAbstractLocalizedString> localizedStrings = descHolder.getDescriptions();
-            return languageStringIn(vecLanguageCode).apply(localizedStrings);
+            return stringIn(vecLanguageCode).apply(localizedStrings);
         };
     }
 
-    public static Function<List<? extends VecAbstractLocalizedString>, Optional<String>> germanLanguageString() {
-        return languageStringIn(VecLanguageCode.DE);
+    public static Function<List<? extends VecAbstractLocalizedString>, Optional<String>> germanString() {
+        return stringIn(VecLanguageCode.DE);
     }
 
-    public static Function<List<? extends VecAbstractLocalizedString>, Optional<String>> englishLanguageString() {
-        return languageStringIn(VecLanguageCode.EN);
+    public static Function<List<? extends VecAbstractLocalizedString>, Optional<String>> englishString() {
+        return stringIn(VecLanguageCode.EN);
     }
 
-    public static Function<List<? extends VecAbstractLocalizedString>, Optional<String>> languageStringIn(
+    public static Function<List<? extends VecAbstractLocalizedString>, Optional<String>> stringIn(
             final VecLanguageCode vecLanguageCode) {
         return localizedStrings -> {
             if (localizedStrings.isEmpty()) {
@@ -93,17 +93,17 @@ public final class DescriptionNavs {
         };
     }
 
-    public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> germanTypedLanguageStringBy(
+    public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> germanTypedStringBy(
             final String descriptionType) {
-        return typedLanguageStringBy(descriptionType, VecLanguageCode.DE);
+        return typedStringBy(descriptionType, VecLanguageCode.DE);
     }
 
-    public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> englishTypedLanguageStringBy(
+    public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> englishTypedStringBy(
             final String descriptionType) {
-        return typedLanguageStringBy(descriptionType, VecLanguageCode.EN);
+        return typedStringBy(descriptionType, VecLanguageCode.EN);
     }
 
-    public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> typedLanguageStringBy(
+    public static Function<HasDescription<? extends VecAbstractLocalizedString>, Optional<String>> typedStringBy(
             final String descriptionType, final VecLanguageCode vecLanguageCode) {
         return hasDescription -> hasDescription.getDescriptions().stream()
                 .filter(VecPredicates.isLanguageCode(vecLanguageCode))

--- a/vec120/src/main/java/com/foursoft/vecmodel/vec120/navigations/DocumentVersionNavs.java
+++ b/vec120/src/main/java/com/foursoft/vecmodel/vec120/navigations/DocumentVersionNavs.java
@@ -1,0 +1,114 @@
+/*-
+ * ========================LICENSE_START=================================
+ * vec120
+ * %%
+ * Copyright (C) 2020 - 2022 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.vecmodel.vec120.navigations;
+
+import com.foursoft.vecmodel.vec120.*;
+import com.foursoft.vecmodel.vec120.utils.StreamUtils;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Navigation methods for the {@link VecDocumentVersion}.
+ */
+public final class DocumentVersionNavs {
+
+    private DocumentVersionNavs() {
+        // hide default constructor
+    }
+
+    public static Function<VecDocumentVersion, List<VecGeometryNode3D>> geometryNodes3DBy(
+            final VecTopologyNode topologyNode) {
+        return documentVersion -> documentVersion.getSpecificationsWithType(VecBuildingBlockSpecification3D.class)
+                .stream()
+                .map(VecBuildingBlockSpecification3D::getGeometryNodes)
+                .flatMap(Collection::stream)
+                .filter(node3D -> node3D.getReferenceNode().equals(topologyNode))
+                .collect(Collectors.toList());
+    }
+
+    public static Function<VecDocumentVersion, List<VecGeometrySegment3D>> geometrySegments3DBy(
+            final VecTopologySegment topologySegment) {
+        return documentVersion -> documentVersion.getSpecificationsWithType(VecBuildingBlockSpecification3D.class)
+                .stream()
+                .map(VecBuildingBlockSpecification3D::getGeometrySegments)
+                .flatMap(Collection::stream)
+                .filter(segment3D -> segment3D.getReferenceSegment().equals(topologySegment))
+                .collect(Collectors.toList());
+    }
+
+    public static Function<VecDocumentVersion, List<VecOccurrenceOrUsageViewItem3D>> viewItems3DBy(
+            final VecOccurrenceOrUsage occurrence) {
+        return documentVersion -> SpecificationNavs
+                .specificationOf(VecBuildingBlockSpecification3D.class)
+                .apply(documentVersion)
+                .map(specification -> specification
+                        .getPlacedElementViewItem3Ds().stream()
+                        .filter(viewItem -> viewItem.getOccurrenceOrUsage().contains(occurrence))
+                        .collect(Collectors.toList()))
+                .orElse(Collections.emptyList());
+    }
+
+    public static Function<VecDocumentVersion, Optional<VecTopologyNode>> topologyNodeBy(
+            final String occurrenceIdentification) {
+        return documentVersion -> documentVersion
+                .getSpecificationsWithType(VecCompositionSpecification.class).stream()
+                .map(VecCompositionSpecification::getComponents)
+                .flatMap(Collection::stream)
+                .filter(occurrence -> occurrence.getIdentification().equals(occurrenceIdentification))
+                .map(PartOccurrenceOrUsageNavs.topologyNodeByOccurrenceOrUsage())
+                .flatMap(StreamUtils.unwrapOptional())
+                .collect(StreamUtils.findOneOrNone());
+    }
+
+    /**
+     * Navigation method to get the {@link VecNodeLocation}s from a given {@link VecPlaceableElementRole}.
+     *
+     * @param placedElement Placed Element the {@link VecOnPointPlacement} needs to contain.
+     *                      May be {@code null} to not filter for this.
+     * @return A possibly-empty list of VecNodeLocations.
+     */
+    public static Function<VecDocumentVersion, List<VecNodeLocation>> nodeLocationsBy(
+            final VecPlaceableElementRole placedElement) {
+        return documentVersion -> documentVersion
+                .getSpecificationsWithType(VecPlacementSpecification.class).stream()
+                .map(VecPlacementSpecification::getPlacements)
+                .flatMap(Collection::stream)
+                .filter(VecOnPointPlacement.class::isInstance)
+                .map(VecOnPointPlacement.class::cast)
+                .filter(c -> placedElement == null || c.getPlacedElement().contains(placedElement))
+                .map(VecOnPointPlacement::getLocations)
+                .flatMap(Collection::stream)
+                .filter(VecNodeLocation.class::isInstance)
+                .map(VecNodeLocation.class::cast)
+                .collect(Collectors.toList());
+    }
+
+}

--- a/vec120/src/main/java/com/foursoft/vecmodel/vec120/navigations/PartOccurrenceOrUsageNavs.java
+++ b/vec120/src/main/java/com/foursoft/vecmodel/vec120/navigations/PartOccurrenceOrUsageNavs.java
@@ -1,0 +1,162 @@
+/*-
+ * ========================LICENSE_START=================================
+ * vec120
+ * %%
+ * Copyright (C) 2020 - 2022 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.vecmodel.vec120.navigations;
+
+import com.foursoft.vecmodel.common.annotations.RequiresBackReferences;
+import com.foursoft.vecmodel.vec120.*;
+import com.foursoft.vecmodel.vec120.utils.StreamUtils;
+import com.foursoft.vecmodel.vec120.utils.StringUtils;
+import com.foursoft.vecmodel.vec120.visitor.ReferencedNodeLocationVisitor;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * Navigation methods for the {@link VecOccurrenceOrUsage} including {@link VecPartOccurrence} and {@link VecPartUsage}.
+ */
+public final class PartOccurrenceOrUsageNavs {
+
+    private PartOccurrenceOrUsageNavs() {
+        // hide default constructor
+    }
+
+    // VecPartOccurrence
+
+    @RequiresBackReferences
+    public static Function<VecPartOccurrence, String> parentDocumentNumber() {
+        return occurrence -> {
+            final VecCompositionSpecification compSpec = occurrence.getParentCompositionSpecification();
+            return SpecificationNavs.parentDocumentNumber().apply(compSpec);
+        };
+    }
+
+    public static Function<VecPartOccurrence, Optional<String>> partNumber() {
+        return occurrence -> Optional.of(occurrence)
+                .map(VecPartOccurrence::getPart)
+                .map(VecPartVersion::getPartNumber)
+                .map(StringUtils::collapseMultipleWhitespaces);
+    }
+
+    public static Function<VecPartOccurrence, Optional<String>> partVersion() {
+        return occurrence -> Optional.of(occurrence)
+                .map(VecPartOccurrence::getPart)
+                .map(VecPartVersion::getPartVersion)
+                .map(StringUtils::collapseMultipleWhitespaces);
+    }
+
+    public static Function<VecPartOccurrence, VecPrimaryPartType> primaryPartType() {
+        return occurrence -> {
+            final VecPartVersion partVersion = occurrence.getPart();
+            return partVersion != null
+                    ? partVersion.getPrimaryPartType()
+                    :
+                    occurrence.getRealizedPartUsage()
+                            .stream()
+                            .collect(StreamUtils.findOneOrNone())
+                            .map(VecPartUsage::getPrimaryPartUsageType)
+                            .orElse(VecPrimaryPartType.OTHER);
+        };
+    }
+
+    /**
+     * Determines the parent {@link VecDocumentVersion} of a {@link VecPartOccurrence}.
+     * <p>
+     * <b>Warning: This uses {@link RequiresBackReferences back references}!</b>
+     *
+     * @return The parent VecDocumentVersion of a VecPartOccurrence.
+     */
+    @RequiresBackReferences
+    public static Function<VecPartOccurrence, VecDocumentVersion> parentDocumentVersion() {
+        return occurrence -> {
+
+            final VecCompositionSpecification parentCompositionSpecification =
+                    occurrence.getParentCompositionSpecification();
+
+            return SpecificationNavs.parentDocumentVersion().apply(parentCompositionSpecification);
+        };
+    }
+
+    /**
+     * Function to determine the {@link VecModuleFamily} for a PartOccurrence.
+     * Note that the PartOccurrence has to be a module in order to be checked.
+     *
+     * @return An empty optional if the tested PartOccurrence is not a module or if no family was found.
+     */
+    public static Function<VecPartOccurrence, Optional<VecModuleFamily>> moduleFamily() {
+        return occurrence -> {
+            // Can also be an assembly though!
+            final boolean isModule = occurrence.getPart().getPrimaryPartType() == VecPrimaryPartType.PART_STRUCTURE;
+
+            return !isModule
+                    ? Optional.empty()
+                    :
+                    occurrence.getRolesWithType(VecPartWithSubComponentsRole.class).stream()
+                            .flatMap(StreamUtils.toStream(VecPartWithSubComponentsRole::getRefModuleFamily))
+                            .collect(StreamUtils.findOneOrNone());
+        };
+    }
+
+    // VecOccurrenceOrUsage
+
+    public static BiFunction<VecOccurrenceOrUsage, VecDocumentVersion, Optional<VecTopologyNode>> findNodeOfComponent() {
+        return (component, documentVersion) -> component.getRolesWithType(VecPlaceableElementRole.class).stream()
+                .findFirst()  // there should be at most one such role
+                .flatMap(placedElement -> DocumentVersionNavs
+                        .nodeLocationsBy(placedElement)
+                        .apply(documentVersion)
+                        .stream()
+                        .collect(StreamUtils.findOneOrNone()))
+                .map(VecNodeLocation::getReferencedNode);
+    }
+
+    public static Function<VecOccurrenceOrUsage, Optional<VecTopologyNode>> topologyNodeByOccurrenceOrUsage() {
+        final ReferencedNodeLocationVisitor visitor = new ReferencedNodeLocationVisitor();
+        return occurrence -> occurrence.getRolesWithType(VecPlaceableElementRole.class).stream()
+                .map(VecPlaceableElementRole::getRefPlacement)
+                .flatMap(Collection::stream)
+                .filter(VecOnPointPlacement.class::isInstance)
+                .map(VecOnPointPlacement.class::cast)
+                .map(VecOnPointPlacement::getLocations)
+                .flatMap(Collection::stream)
+                .map(location -> location.accept(visitor))
+                .collect(StreamUtils.findOneOrNone());
+    }
+
+    public static Function<VecOccurrenceOrUsage, Optional<VecPartOccurrence>> occurrence() {
+        return occurrenceOrUsage -> Optional.of(occurrenceOrUsage)
+                .filter(VecPartOccurrence.class::isInstance)
+                .map(VecPartOccurrence.class::cast);
+    }
+
+    public static Function<VecOccurrenceOrUsage, Optional<VecPartUsage>> usage() {
+        return occurrenceOrUsage -> Optional.of(occurrenceOrUsage)
+                .filter(VecPartUsage.class::isInstance)
+                .map(VecPartUsage.class::cast);
+    }
+
+}

--- a/vec120/src/main/java/com/foursoft/vecmodel/vec120/navigations/PlacementNavs.java
+++ b/vec120/src/main/java/com/foursoft/vecmodel/vec120/navigations/PlacementNavs.java
@@ -1,0 +1,98 @@
+/*-
+ * ========================LICENSE_START=================================
+ * vec120
+ * %%
+ * Copyright (C) 2020 - 2022 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.vecmodel.vec120.navigations;
+
+import com.foursoft.vecmodel.vec120.*;
+import com.foursoft.vecmodel.vec120.utils.StreamUtils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Navigation methods for getting {@link VecPlacement}s.
+ */
+public final class PlacementNavs {
+
+    private PlacementNavs() {
+        // hide default constructor
+    }
+
+    public static Function<VecPlaceableElementRole, Stream<VecOnPointPlacement>> onPointPlacement() {
+        return role -> role.getRefPlacement().stream()
+                .filter(VecOnPointPlacement.class::isInstance)
+                .map(VecOnPointPlacement.class::cast);
+    }
+
+    public static Function<VecPlaceableElementRole, Stream<VecOnWayPlacement>> onWayPlacement() {
+        return role -> role.getRefPlacement().stream()
+                .filter(VecOnWayPlacement.class::isInstance)
+                .map(VecOnWayPlacement.class::cast);
+    }
+
+    /**
+     * Returns the locations from a {@link VecOccurrenceOrUsageViewItem3D}.
+     *
+     * @param placement Placement Navigation method.
+     * @return A function to get the locations from a VecOccurrenceOrUsageViewItem3D.
+     * @see #onWayPlacement()
+     * @see #onPointPlacement()
+     */
+    public static Function<VecOccurrenceOrUsageViewItem3D, List<VecLocation>> locationsBy3DOf(
+            final Function<VecPlaceableElementRole, Stream<VecOnPointPlacement>> placement) {
+        return viewItem3D -> locationsOf(placement).apply(viewItem3D.getOccurrenceOrUsage());
+    }
+
+    /**
+     * Returns the locations from a {@link VecOccurrenceOrUsageViewItem2D}.
+     *
+     * @param placement Placement Navigation method.
+     * @return A function to get the locations from a VecOccurrenceOrUsageViewItem2D.
+     * @see #onWayPlacement()
+     * @see #onPointPlacement()
+     */
+    public static Function<VecOccurrenceOrUsageViewItem2D, List<VecLocation>> locationsBy2DOf(
+            final Function<VecPlaceableElementRole, Stream<VecOnPointPlacement>> placement) {
+        return viewItem2D -> locationsOf(placement).apply(viewItem2D.getOccurrenceOrUsage());
+    }
+
+    private static Function<List<VecOccurrenceOrUsage>, List<VecLocation>> locationsOf(
+            final Function<VecPlaceableElementRole, Stream<VecOnPointPlacement>> placement) {
+        return occurrenceOrUsages -> occurrenceOrUsages.stream()
+                .filter(VecPartOccurrence.class::isInstance)
+                .map(VecPartOccurrence.class::cast)
+                .flatMap(StreamUtils.toStream(c -> c.getRolesWithType(VecPlaceableElementRole.class)))
+                .collect(StreamUtils.findOneOrNone())
+                .map(role -> placement.apply(role)
+                        .map(VecOnPointPlacement::getLocations)
+                        .flatMap(List::stream)
+                        .collect(Collectors.toList()))
+                .orElseGet(Collections::emptyList);
+    }
+
+}

--- a/vec120/src/main/java/com/foursoft/vecmodel/vec120/navigations/SegmentNavs.java
+++ b/vec120/src/main/java/com/foursoft/vecmodel/vec120/navigations/SegmentNavs.java
@@ -1,0 +1,70 @@
+/*-
+ * ========================LICENSE_START=================================
+ * vec120
+ * %%
+ * Copyright (C) 2020 - 2022 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.vecmodel.vec120.navigations;
+
+import com.foursoft.vecmodel.common.annotations.RequiresBackReferences;
+import com.foursoft.vecmodel.vec120.VecNumericalValue;
+import com.foursoft.vecmodel.vec120.VecSegmentCrossSectionArea;
+import com.foursoft.vecmodel.vec120.VecSegmentLength;
+import com.foursoft.vecmodel.vec120.VecTopologySegment;
+import com.foursoft.vecmodel.vec120.utils.StreamUtils;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Navigation methods for segments such as the {@link VecTopologySegment}.
+ */
+public final class SegmentNavs {
+
+    private SegmentNavs() {
+        // hide default constructor
+    }
+
+    @RequiresBackReferences
+    public static Function<VecTopologySegment, String> parentDocumentNumber() {
+        return segment -> segment.getParentTopologySpecification().getParentDocumentVersion().getDocumentNumber();
+    }
+
+    // TODO Make the segmentLengthClassification an Open Enumeration
+    public static Function<VecTopologySegment, Optional<Double>> lengthBy(final String segmentLengthClassification) {
+        return segment -> StreamUtils.nonNullStream(segment.getLengthInformations())
+                .filter(segmentLength -> segmentLength.getClassification().equals(segmentLengthClassification))
+                .collect(StreamUtils.findOneOrNone())
+                .map(VecSegmentLength::getLength)
+                .map(VecNumericalValue::getValueComponent);
+    }
+
+    public static Function<VecTopologySegment, Optional<Double>> crossSectionAreaBy(final String areaType) {
+        return segment -> StreamUtils.nonNullStream(segment.getCrossSectionAreaInformations())
+                .filter(seg -> Objects.equals(areaType, seg.getCrossSectionAreaType()))  // is nullable
+                .collect(StreamUtils.findOneOrNone())
+                .map(VecSegmentCrossSectionArea::getArea)
+                .map(VecNumericalValue::getValueComponent);
+    }
+
+}

--- a/vec120/src/main/java/com/foursoft/vecmodel/vec120/navigations/SpecificationNavs.java
+++ b/vec120/src/main/java/com/foursoft/vecmodel/vec120/navigations/SpecificationNavs.java
@@ -1,0 +1,100 @@
+/*-
+ * ========================LICENSE_START=================================
+ * vec120
+ * %%
+ * Copyright (C) 2020 - 2022 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.vecmodel.vec120.navigations;
+
+import com.foursoft.vecmodel.common.HasSpecifications;
+import com.foursoft.vecmodel.common.annotations.RequiresBackReferences;
+import com.foursoft.vecmodel.vec120.*;
+import com.foursoft.vecmodel.vec120.utils.StreamUtils;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+/**
+ * Navigation methods for the {@link VecSpecification}.
+ */
+public final class SpecificationNavs {
+
+    private SpecificationNavs() {
+        // hide default constructor
+    }
+
+    /**
+     * Gets the first specification with the given type.
+     * <b>Warning: There might be multiple specifications with the given type.
+     * Only use this method if you are sure there will just be one element!</b>
+     *
+     * @param type Class of T.
+     * @param <T>  Type of Specification to filter for.
+     * @return The first specification with the given type if found, else an empty optional.
+     */
+    public static <T extends VecSpecification> Function<HasSpecifications<VecSpecification>, Optional<T>> specificationOf(
+            final Class<T> type) {
+        return hasSpecification -> hasSpecification.getSpecificationsWithType(type)
+                .stream().collect(StreamUtils.findOneOrNone());
+    }
+
+    public static <T extends VecSpecification> Function<HasSpecifications<VecSpecification>, Optional<T>> specificationOf(
+            final Class<T> type, final String specificationType) {
+        return hasSpecification -> hasSpecification.getSpecificationsWithType(type)
+                .stream()
+                .filter(spec -> specificationType.equals(spec.getIdentification()))
+                .collect(StreamUtils.findOneOrNone());
+    }
+
+    @RequiresBackReferences
+    public static Function<VecSpecification, String> parentDocumentNumber() {
+        return spec -> parentDocumentVersion().apply(spec).getDocumentNumber();
+    }
+
+    public static Function<HasSpecifications<VecSpecification>, Stream<VecOccurrenceOrUsage>> allOccurrenceOrUsages() {
+        return hasSpecifications -> Stream.concat(
+                hasSpecifications.getSpecificationsWithType(VecCompositionSpecification.class)
+                        .stream()
+                        .map(VecCompositionSpecification::getComponents)
+                        .flatMap(Collection::stream),
+                hasSpecifications.getSpecificationsWithType(VecPartUsageSpecification.class)
+                        .stream()
+                        .map(VecPartUsageSpecification::getPartUsages)
+                        .flatMap(Collection::stream));
+    }
+
+    @RequiresBackReferences
+    public static Function<VecSpecification, VecDocumentVersion> parentDocumentVersion() {
+        return specification -> {
+            final VecSheetOrChapter sheetOrChapter = specification.getParentSheetOrChapter();
+            final VecDocumentVersion documentVersion = specification.getParentDocumentVersion();
+            if (documentVersion != null) {
+                return documentVersion;
+            } else {
+                return sheetOrChapter.getParentDocumentVersion();
+            }
+        };
+    }
+
+}

--- a/vec120/src/main/java/com/foursoft/vecmodel/vec120/navigations/VecNavs.java
+++ b/vec120/src/main/java/com/foursoft/vecmodel/vec120/navigations/VecNavs.java
@@ -1,0 +1,64 @@
+/*-
+ * ========================LICENSE_START=================================
+ * vec120
+ * %%
+ * Copyright (C) 2020 - 2022 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.vecmodel.vec120.navigations;
+
+import com.foursoft.vecmodel.common.annotations.RequiresBackReferences;
+import com.foursoft.vecmodel.vec120.*;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Navigation methods which don't fit into a special category.
+ */
+public final class VecNavs {
+
+    private VecNavs() {
+        // hide default constructor
+    }
+
+    public static Function<VecExtendableElement, List<String>> externalDocumentNumbers() {
+        return element -> element.getReferencedExternalDocuments().stream()
+                .map(VecDocumentVersion::getDocumentNumber)
+                .collect(Collectors.toList());
+    }
+
+    @RequiresBackReferences
+    public static Function<VecRole, VecDocumentVersion> parentDocumentVersion() {
+        return role -> {
+            final VecOccurrenceOrUsage parentOccurrenceOrUsage = role.getParentOccurrenceOrUsage();
+            if (parentOccurrenceOrUsage instanceof VecPartOccurrence) {
+                return PartOccurrenceOrUsageNavs.parentDocumentVersion().apply((VecPartOccurrence) parentOccurrenceOrUsage);
+            } else {
+                final VecPartUsageSpecification parentPartUsageSpecification =
+                        ((VecPartUsage) parentOccurrenceOrUsage).getParentPartUsageSpecification();
+                return SpecificationNavs.parentDocumentVersion().apply(parentPartUsageSpecification);
+            }
+        };
+    }
+
+}

--- a/vec120/src/main/java/com/foursoft/vecmodel/vec120/predicates/VecPredicates.java
+++ b/vec120/src/main/java/com/foursoft/vecmodel/vec120/predicates/VecPredicates.java
@@ -1,0 +1,212 @@
+/*-
+ * ========================LICENSE_START=================================
+ * vec120
+ * %%
+ * Copyright (C) 2020 - 2022 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.vecmodel.vec120.predicates;
+
+import com.foursoft.vecmodel.common.annotations.RequiresBackReferences;
+import com.foursoft.vecmodel.vec120.*;
+import com.foursoft.vecmodel.vec120.utils.StreamUtils;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * Uncategorized {@link Predicate} methods.
+ */
+public final class VecPredicates {
+
+    private VecPredicates() {
+        // hide default constructor
+    }
+
+    public static Predicate<VecPlaceableElementRole> isOnWayPlacement() {
+        return c -> c.getPlaceableElementSpecification().getValidPlacementTypes()
+                .stream()
+                .anyMatch(VecPlacementType.ON_WAY::equals);
+    }
+
+    public static Predicate<VecPlaceableElementRole> isOnPointPlacement() {
+        return c -> c.getPlaceableElementSpecification().getValidPlacementTypes()
+                .stream()
+                .anyMatch(VecPlacementType.ON_POINT::equals);
+    }
+
+    public static Predicate<VecAbstractLocalizedString> isGermanLanguageCode() {
+        return isLanguageCode(VecLanguageCode.DE);
+    }
+
+    public static Predicate<VecAbstractLocalizedString> isEnglishLanguageCode() {
+        return isLanguageCode(VecLanguageCode.EN);
+    }
+
+    public static Predicate<VecAbstractLocalizedString> isLanguageCode(final VecLanguageCode code) {
+        return localizedString -> code == localizedString.getLanguageCode();
+    }
+
+    /**
+     * Checks if an {@link VecEEComponentRole} is of specific subtype (which not
+     * expressed by inheritance of {@link VecEEComponentRole}, but by
+     * inheritance of the corresponding {@link VecEEComponentSpecification}.
+     *
+     * @param specificClass the class to check against.
+     */
+    public static Predicate<VecEEComponentRole> isEEComponentOfSpecificType(
+            final Class<? extends VecEEComponentSpecification> specificClass) {
+        return role -> specificClass.isInstance(role.getEEComponentSpecification());
+    }
+
+    /**
+     * Checks if an {@link VecPartOccurrence} is of specific subtype (which not
+     * expressed by inheritance of {@link VecEEComponentRole}, but by
+     * inheritance of the corresponding {@link VecEEComponentSpecification}.
+     */
+    public static Predicate<VecOccurrenceOrUsage> isFuse() {
+        return occ -> occ.getRolesWithType(VecEEComponentRole.class).stream()
+                .anyMatch(isEEComponentOfSpecificType(VecFuseSpecification.class)
+                        .or(isEEComponentOfSpecificType(VecMultiFuseSpecification.class)));
+    }
+
+    /**
+     * Checks if an {@link VecPartOccurrence} is of specific subtype (which not
+     * expressed by inheritance of {@link VecEEComponentRole}, but by
+     * inheritance of the corresponding {@link VecEEComponentSpecification}.
+     */
+    public static Predicate<VecOccurrenceOrUsage> isRelay() {
+        return occ -> occ.getRolesWithType(VecEEComponentRole.class).stream()
+                .anyMatch(isEEComponentOfSpecificType(VecRelaySpecification.class));
+    }
+
+    @RequiresBackReferences
+    public static Predicate<VecWireElementReference> isRootWireElementReference() {
+        return reference -> {
+            final VecWireElement referencedWireElement = reference.getReferencedWireElement();
+            final VecWireSpecification wireSpecification = referencedWireElement.getParentWireSpecification();
+            return wireSpecification != null &&
+                    referencedWireElement.getWireElementSpecification()
+                            .equals(wireSpecification.getWireElementSpecification());
+        };
+    }
+
+    /**
+     * Checks if a {@link VecWireElementReference} is a single wire element reference.
+     * <p>
+     * Notice: Master data context is not checked!
+     *
+     * @return Predicate to check if the tested WireElementReference is single.
+     */
+    @RequiresBackReferences
+    public static Predicate<VecWireElementReference> isSingleWireElementReference() {
+        return reference -> reference.getParentWireRole().getWireElementReferences().size() == 1;
+    }
+
+    // TODO Use enum for SpecialPartType when available
+    public static Predicate<VecDocumentVersion> isAssembly() {
+        return doc -> doc.getSpecifications().stream()
+                .flatMap(StreamUtils.ofClass(VecPartStructureSpecification.class))
+                .anyMatch(spec -> "Assembly".equals(spec.getSpecialPartType()));
+    }
+
+    /**
+     * Checks if a PartOccurrence is an assembly.
+     * <p>
+     * This check depends on the context, for a module this will also be {@code true}.
+     *
+     * @return Check to test if a PartOccurrence is an assembly.
+     */
+    public static Predicate<VecPartOccurrence> isAssemblyOccurrence() {
+        return occ -> !occ.getRolesWithType(VecPartWithSubComponentsRole.class).isEmpty();
+    }
+
+    public static Predicate<VecOccurrenceOrUsage> isPartUsage() {
+        return VecPartUsage.class::isInstance;
+    }
+
+    public static Predicate<VecOccurrenceOrUsage> isPartOccurrence() {
+        return VecPartOccurrence.class::isInstance;
+    }
+
+    public static Predicate<VecPartOccurrence> isWire() {
+        return occ -> !occ.getRolesWithType(VecWireRole.class).isEmpty();
+    }
+
+    public static Predicate<VecPartOccurrence> isPlug() {
+        return occ -> !occ.getRolesWithType(VecCavityPlugRole.class).isEmpty();
+    }
+
+    public static Predicate<VecPartVersion> isEqualPartVersion(final VecPartVersion comparePartVersion) {
+        return partVersion -> partVersion.getPartNumber().equals(comparePartVersion.getPartNumber())
+                && partVersion.getPartVersion().equals(comparePartVersion.getPartVersion())
+                && partVersion.getCompanyName().equals(comparePartVersion.getCompanyName())
+                && partVersion.getPrimaryPartType() == comparePartVersion.getPrimaryPartType();
+    }
+
+    public static Predicate<VecSIUnit> isEqualSiUnit(final VecSIUnit compareUnit) {
+        return unit -> unit.getSiUnitName() == compareUnit.getSiUnitName()
+                && unit.getSiPrefix() == compareUnit.getSiPrefix()
+                && Objects.equals(unit.getExponent(), compareUnit.getExponent());
+    }
+
+    public static Predicate<VecUSUnit> isEqualUsUnit(final VecUSUnit compareUnit) {
+        return unit -> unit.getUsUnitName() == compareUnit.getUsUnitName()
+                && Objects.equals(unit.getExponent(), compareUnit.getExponent());
+    }
+
+    public static Predicate<VecCompositeUnit> isEqualCompositeUnit(final VecCompositeUnit compareUnit) {
+        return unit -> unit.getFactors().stream()
+                .allMatch(u -> compareUnit.getFactors().stream().anyMatch(isEqualUnit(u)))
+                && Objects.equals(unit.getExponent(), compareUnit.getExponent());
+    }
+
+    public static Predicate<VecUnit> isEqualUnit(final VecUnit compareUnit) {
+        return unit -> {
+            if (unit instanceof VecSIUnit && compareUnit instanceof VecSIUnit) {
+                return isEqualSiUnit((VecSIUnit) compareUnit).test((VecSIUnit) unit);
+            }
+
+            if (unit instanceof VecUSUnit && compareUnit instanceof VecUSUnit) {
+                return isEqualUsUnit((VecUSUnit) compareUnit).test((VecUSUnit) unit);
+            }
+
+            if (unit instanceof VecCompositeUnit && compareUnit instanceof VecCompositeUnit) {
+                return isEqualCompositeUnit((VecCompositeUnit) compareUnit).test((VecCompositeUnit) unit);
+            }
+            return false;
+        };
+    }
+
+    public static Predicate<VecContract> isEqualContract(final VecContract compareContract) {
+        return contract -> contract.getContractRole().equals(compareContract.getContractRole()) &&
+                contract.getCompanyName().equals(compareContract.getCompanyName());
+    }
+
+    public static Predicate<VecOnPointPlacement> isOnPointPlacementOf(final VecTopologyNode topologyNode) {
+        return vecPlacement -> vecPlacement.getLocations().stream()
+                .filter(VecNodeLocation.class::isInstance)
+                .map(VecNodeLocation.class::cast)
+                .map(VecNodeLocation::getReferencedNode)
+                .anyMatch(n -> n.equals(topologyNode));
+    }
+
+}

--- a/vec120/src/main/java/com/foursoft/vecmodel/vec120/utils/StreamUtils.java
+++ b/vec120/src/main/java/com/foursoft/vecmodel/vec120/utils/StreamUtils.java
@@ -1,0 +1,187 @@
+/*-
+ * ========================LICENSE_START=================================
+ * vec120
+ * %%
+ * Copyright (C) 2020 - 2022 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.vecmodel.vec120.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collector;
+import java.util.stream.Stream;
+
+/**
+ * Utility class that contains helping methods for Streams.
+ */
+public final class StreamUtils {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StreamUtils.class);
+
+    private StreamUtils() {
+        // hide default constructor
+    }
+
+    /**
+     * Removes empty {@link Optional}s from a Stream and unwraps them, when used as a "flatMapper".
+     *
+     * @return Unwrapped optional.
+     * @see Stream#flatMap(Function)
+     */
+    public static <S> Function<Optional<S>, Stream<S>> unwrapOptional() {
+        return o -> o.map(Stream::of)
+                .orElseGet(Stream::empty);
+    }
+
+    /**
+     * Returns a function which returns a stream from the given function.
+     * <p>
+     * Can be used together with {@link Stream#flatMap(Function)} to cast the stream.
+     * <pre>
+     * {@code
+     * List&lt;Person&gt; people = streamOfHouses
+     *   .flatMap(StreamUtils.toStream(House::getPeople))
+     *   .collect(Collectors.toList());
+     * }
+     * </pre>
+     *
+     * @param inputFunction Function to create a Stream.
+     * @param <T>           Input Type of the Function.
+     * @param <R>           Type of the Collection within the given function. Will also determine the type of the Stream.
+     * @return A stream of the applied Function.
+     */
+    public static <T, R> Function<T, Stream<R>> toStream(final Function<T, Collection<R>> inputFunction) {
+        return t -> inputFunction.apply(t)
+                .stream();
+    }
+
+    /**
+     * Returns an optional with the first element of a list if available, else an empty optional.
+     * <p>
+     * If the list contains more than one element, a debug log entry is fired.
+     * It also contains the calling stacktrace attached if {@link Logger#isDebugEnabled()} is {@code true}.
+     */
+    public static <T> Collector<T, List<T>, Optional<T>> findOneOrNone() {
+        return Collector.of(ArrayList::new, List::add, (left, right) -> {
+            left.addAll(right);
+            return left;
+        }, list -> {
+            if (list.isEmpty()) {
+                return Optional.empty();
+            }
+            if (list.size() > 1) {
+                final String message =
+                        "Did find more than one element in list; will choose first one. All elements: {}";
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug(message, list, new IllegalArgumentException("Too many elements found in list."));
+                } else {
+                    LOGGER.debug(message, list);
+                }
+            }
+            return Optional.ofNullable(list.get(0));
+        });
+    }
+
+    /**
+     * Returns the only element in the list. If zero or more than one element is in the list, an exception is thrown.
+     */
+    public static <T> Collector<T, List<T>, T> findOne() {
+        return Collector.of(ArrayList::new, List::add, (left, right) -> {
+            left.addAll(right);
+            return left;
+        }, list -> {
+            if (list.size() != 1) {
+                throw new IllegalStateException("Did find zero or more than one element in list: " + list);
+            }
+            return list.get(0);
+        });
+    }
+
+    /**
+     * Returns a Function which returns a Stream of elements of the given class.
+     * <p>
+     * Can be used together with {@link Stream#flatMap(Function)} to filter the stream.
+     * <pre>
+     * {@code
+     * List&lt;Developer&gt; developers = streamOfPeople
+     *   .flatMap(StreamUtils.ofClass(Developer.class))
+     *   .collect(Collectors.toList());
+     * }
+     * </pre>
+     *
+     * @param classOfT Class an element must have to stay in the stream.
+     * @param <E>      Input type of the function.
+     * @param <T>      Type of the class which the stream should have.
+     * @return A stream with the input cast to the given class if applicable.
+     * If this is not the case, an empty stream will be returned.
+     */
+    public static <E, T> Function<E, Stream<T>> ofClass(final Class<T> classOfT) {
+        return t -> {
+            if (t == null || !classOfT.isAssignableFrom(t.getClass())) {
+                return Stream.empty();
+            }
+            return Stream.of(classOfT.cast(t));
+        };
+    }
+
+    /**
+     * Filters a given stream checking if an element is an instance of the given class and casts to it.
+     *
+     * @param stream Stream to check and cast to the given class.
+     * @param clazz  Class which should be checked and cast to.
+     * @param <I>    Input type.
+     * @param <O>    Output type.
+     * @return Stream of the type of the given class.
+     */
+    public static <I, O> Stream<O> checkAndCast(final Stream<I> stream, final Class<O> clazz) {
+        return stream
+                .flatMap(ofClass(clazz));
+    }
+
+    /**
+     * Streams and filters a given collection checking if an element is an instance of the given class and casts to it.
+     *
+     * @param collection Collection to stream, check and cast to the given class.
+     * @param clazz      Class which should be checked and cast to.
+     * @param <I>        Input type.
+     * @param <O>        Output type.
+     * @return Stream of the type of the given class.
+     */
+    public static <I, O> Stream<O> checkAndCast(final Collection<I> collection, final Class<O> clazz) {
+        return checkAndCast(collection.stream(), clazz);
+    }
+
+    /**
+     * Returns a stream of the given {@link Collection} and removes {@code null} elements from it.
+     *
+     * @param collection Collection to stream.
+     * @param <T>        Type of the Collection / Stream.
+     * @return A Stream of the given Collection without {@code null} elements.
+     */
+    public static <T> Stream<T> nonNullStream(final Collection<T> collection) {
+        return collection.stream().filter(Objects::nonNull);
+    }
+
+}

--- a/vec120/src/main/java/com/foursoft/vecmodel/vec120/utils/StringUtils.java
+++ b/vec120/src/main/java/com/foursoft/vecmodel/vec120/utils/StringUtils.java
@@ -1,0 +1,50 @@
+/*-
+ * ========================LICENSE_START=================================
+ * vec120
+ * %%
+ * Copyright (C) 2020 - 2022 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.vecmodel.vec120.utils;
+
+import java.util.regex.Pattern;
+
+public final class StringUtils {
+
+    private static final Pattern WHITE_SPACE_REGEX = Pattern.compile("\\s+");
+
+    private StringUtils() {
+        // hide default constructor
+    }
+
+    public static boolean isEmpty(final String s) {
+        return s == null || s.isEmpty();
+    }
+
+    public static boolean isNotEmpty(final String s) {
+        return !isEmpty(s);
+    }
+
+    public static String collapseMultipleWhitespaces(final String in) {
+        return in == null ? null : WHITE_SPACE_REGEX.matcher(in).replaceAll(" ").trim();
+    }
+
+}

--- a/vec120/src/main/java/com/foursoft/vecmodel/vec120/visitor/ReferencedNodeLocationVisitor.java
+++ b/vec120/src/main/java/com/foursoft/vecmodel/vec120/visitor/ReferencedNodeLocationVisitor.java
@@ -1,0 +1,50 @@
+/*-
+ * ========================LICENSE_START=================================
+ * vec120
+ * %%
+ * Copyright (C) 2020 - 2022 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.vecmodel.vec120.visitor;
+
+import com.foursoft.vecmodel.vec120.*;
+
+public class ReferencedNodeLocationVisitor extends StrictBaseVisitor<VecTopologyNode> {
+
+    @Override
+    public VecTopologyNode visitVecNodeLocation(final VecNodeLocation aBean) {
+        return aBean.getReferencedNode();
+    }
+
+    @Override
+    public VecTopologyNode visitVecSegmentLocation(final VecSegmentLocation aBean) {
+        final VecAnchorType anchor = aBean.getAnchor();
+        if (anchor == null) {
+            return null;
+        }
+
+        final VecTopologySegment referencedSegment = aBean.getReferencedSegment();
+        return VecAnchorType.FROM_START_NODE == anchor
+                ? referencedSegment.getStartNode()
+                : referencedSegment.getEndNode();
+    }
+
+}


### PR DESCRIPTION
## Pull Request

- [x] I have checked for similar PRs.
- [x] I have read the [contributing guidelines](https://github.com/4Soft-de/vec-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [x] Code
- [x] Documentation
- [ ] Other: 

### Description

Adding convenient navigation methods for the VEC 1.2.0. Also introduced a basic annotation `@RequiresBackReferences`
to mark methods. For such methods a manually created `VecContent` might result in exceptions since back references are
not set with that.