### PR TITLE
Added more geometry-relevant navigation methods

### DIFF
--- a/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/ContentNavs.java
+++ b/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/ContentNavs.java
@@ -10,10 +10,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,10 +25,10 @@
  */
 package com.foursoft.harness.vec.v12x.navigations;
 
+import com.foursoft.harness.vec.common.util.StreamUtils;
 import com.foursoft.harness.vec.v12x.VecContent;
 import com.foursoft.harness.vec.v12x.VecDocumentVersion;
 import com.foursoft.harness.vec.v12x.VecSpecification;
-import com.foursoft.harness.vec.common.util.StreamUtils;
 
 import java.util.List;
 import java.util.Optional;
@@ -47,7 +47,7 @@ public final class ContentNavs {
     public static <T extends VecSpecification> Function<VecContent, List<T>> allSpecificationsOf(final Class<T> clazz) {
         return vecContent -> vecContent.getDocumentVersions()
                 .stream()
-                .flatMap(StreamUtils.toStream(dv -> dv.getSpecificationsWithType(clazz)))
+                .flatMap(StreamUtils.toStream(documentVersion -> documentVersion.getSpecificationsWithType(clazz)))
                 .collect(Collectors.toList());
     }
 

--- a/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/DescriptionNavs.java
+++ b/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/DescriptionNavs.java
@@ -10,10 +10,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,13 +25,13 @@
  */
 package com.foursoft.harness.vec.v12x.navigations;
 
+import com.foursoft.harness.vec.common.HasDescription;
+import com.foursoft.harness.vec.common.util.StreamUtils;
+import com.foursoft.harness.vec.common.util.StringUtils;
 import com.foursoft.harness.vec.v12x.VecAbstractLocalizedString;
 import com.foursoft.harness.vec.v12x.VecLanguageCode;
 import com.foursoft.harness.vec.v12x.VecLocalizedTypedString;
 import com.foursoft.harness.vec.v12x.predicates.VecPredicates;
-import com.foursoft.harness.vec.common.HasDescription;
-import com.foursoft.harness.vec.common.util.StreamUtils;
-import com.foursoft.harness.vec.common.util.StringUtils;
 
 import java.util.List;
 import java.util.Optional;
@@ -108,7 +108,7 @@ public final class DescriptionNavs {
         return hasDescription -> hasDescription.getDescriptions().stream()
                 .filter(VecPredicates.isLanguageCode(vecLanguageCode))
                 .flatMap(StreamUtils.ofClass(VecLocalizedTypedString.class))
-                .filter(dv -> descriptionType.equals(dv.getType()))
+                .filter(typedString -> descriptionType.equals(typedString.getType()))
                 .collect(StreamUtils.findOneOrNone())
                 .map(VecLocalizedTypedString::getValue)
                 .filter(StringUtils::isNotEmpty);

--- a/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/DocumentVersionNavs.java
+++ b/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/DocumentVersionNavs.java
@@ -10,10 +10,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,8 +25,8 @@
  */
 package com.foursoft.harness.vec.v12x.navigations;
 
-import com.foursoft.harness.vec.v12x.*;
 import com.foursoft.harness.vec.common.util.StreamUtils;
+import com.foursoft.harness.vec.v12x.*;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -107,6 +107,78 @@ public final class DocumentVersionNavs {
                 .filter(VecNodeLocation.class::isInstance)
                 .map(VecNodeLocation.class::cast)
                 .collect(Collectors.toList());
+    }
+
+    public static Function<VecDocumentVersion, VecGeometryNode2D> geometryNode2DBy(final VecNodeLocation location) {
+        return dv -> dv.getSpecificationWithType(VecBuildingBlockSpecification2D.class)
+                .map(VecBuildingBlockSpecification2D::getGeometryNodes).orElseGet(Collections::emptyList)
+                .stream()
+                .filter(n -> n.getReferenceNode().equals(location.getReferencedNode()))
+                .collect(StreamUtils.findOne());
+    }
+
+    public static Function<VecDocumentVersion, VecGeometryNode3D> geometryNode3DBy(final VecNodeLocation location) {
+        return dv -> dv.getSpecificationWithType(VecBuildingBlockSpecification3D.class)
+                .map(VecBuildingBlockSpecification3D::getGeometryNodes).orElseGet(Collections::emptyList)
+                .stream()
+                .filter(n -> n.getReferenceNode().equals(location.getReferencedNode()))
+                .collect(StreamUtils.findOne());
+    }
+
+    public static Function<VecDocumentVersion, Optional<VecOccurrenceOrUsageViewItem2D>> viewItem2DBy(
+            final String occurrenceOrUsageId) {
+        return dv -> dv.getSpecificationsWithType(VecBuildingBlockSpecification2D.class).stream()
+                .map(VecBuildingBlockSpecification2D::getPlacedElementViewItems)
+                .flatMap(Collection::stream)
+                .filter(item -> item.getOccurrenceOrUsage().stream()
+                        .collect(StreamUtils.findOne())
+                        .getIdentification()
+                        .equals(occurrenceOrUsageId))
+                .findAny();
+    }
+
+    public static Function<VecDocumentVersion, Optional<VecOccurrenceOrUsageViewItem3D>> viewItem3DBy(
+            final String occurrenceOrUsageId) {
+        return dv -> dv.getSpecificationsWithType(VecBuildingBlockSpecification3D.class).stream()
+                .map(VecBuildingBlockSpecification3D::getPlacedElementViewItem3Ds)
+                .flatMap(Collection::stream)
+                .filter(item -> item.getOccurrenceOrUsage().stream()
+                        .collect(StreamUtils.findOne())
+                        .getIdentification()
+                        .equals(occurrenceOrUsageId))
+                .findAny();
+    }
+
+    public static Function<VecDocumentVersion, VecBuildingBlockSpecification2D> buildingBlockSpecification2DBy(
+            final String specificationId) {
+        return dv -> dv.getSpecificationsWithType(VecBuildingBlockSpecification2D.class).stream()
+                .filter(specification -> specification.getIdentification().equals(specificationId))
+                .collect(StreamUtils.findOne());
+    }
+
+    public static Function<VecDocumentVersion, VecBuildingBlockSpecification3D> buildingBlockSpecification3DBy(
+            final String specificationId) {
+        return dv -> dv.getSpecificationsWithType(VecBuildingBlockSpecification3D.class).stream()
+                .filter(specification -> specification.getIdentification().equals(specificationId))
+                .collect(StreamUtils.findOne());
+    }
+
+    public static Function<VecDocumentVersion, Optional<VecBuildingBlockPositioning2D>> positioning2DWith(
+            final VecBuildingBlockSpecification2D buildingBlock) {
+        return dv -> dv.getSpecificationsWithType(VecHarnessDrawingSpecification2D.class).stream()
+                .map(VecHarnessDrawingSpecification2D::getBuildingBlockPositionings)
+                .flatMap(Collection::stream)
+                .filter(positioning -> positioning.getReferenced2DBuildingBlock() == buildingBlock)
+                .collect(StreamUtils.findOneOrNone());
+    }
+
+    public static Function<VecDocumentVersion, Optional<VecBuildingBlockPositioning3D>> positioning3DWith(
+            final VecBuildingBlockSpecification3D buildingBlock) {
+        return dv -> dv.getSpecificationsWithType(VecHarnessGeometrySpecification3D.class).stream()
+                .map(VecHarnessGeometrySpecification3D::getBuildingBlockPositionings)
+                .flatMap(Collection::stream)
+                .filter(positioning -> positioning.getReferenced3DBuildingBlock() == buildingBlock)
+                .collect(StreamUtils.findOneOrNone());
     }
 
 }

--- a/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/DocumentVersionNavs.java
+++ b/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/DocumentVersionNavs.java
@@ -67,12 +67,14 @@ public final class DocumentVersionNavs {
 
     public static Function<VecDocumentVersion, List<VecOccurrenceOrUsageViewItem3D>> viewItems3DBy(
             final VecOccurrenceOrUsage occurrence) {
-        return documentVersion -> documentVersion.getSpecificationWithType(VecBuildingBlockSpecification3D.class)
+        return documentVersion -> documentVersion.getSpecificationsWithType(VecBuildingBlockSpecification3D.class)
+                .stream()
                 .map(specification -> specification
                         .getPlacedElementViewItem3Ds().stream()
                         .filter(viewItem -> viewItem.getOccurrenceOrUsage().contains(occurrence))
                         .collect(Collectors.toList()))
-                .orElse(Collections.emptyList());
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
     }
 
     public static Function<VecDocumentVersion, Optional<VecTopologyNode>> topologyNodeBy(

--- a/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/DocumentVersionNavs.java
+++ b/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/DocumentVersionNavs.java
@@ -79,10 +79,8 @@ public final class DocumentVersionNavs {
 
     public static Function<VecDocumentVersion, Optional<VecTopologyNode>> topologyNodeBy(
             final String occurrenceIdentification) {
-        return documentVersion -> documentVersion
-                .getSpecificationsWithType(VecCompositionSpecification.class).stream()
-                .map(VecCompositionSpecification::getComponents)
-                .flatMap(Collection::stream)
+        return documentVersion -> SpecificationNavs.components().apply(documentVersion)
+                .stream()
                 .filter(occurrence -> occurrence.getIdentification().equals(occurrenceIdentification))
                 .map(PartOccurrenceOrUsageNavs.topologyNodeByOccurrenceOrUsage())
                 .flatMap(StreamUtils.unwrapOptional())

--- a/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/DocumentVersionNavs.java
+++ b/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/DocumentVersionNavs.java
@@ -113,7 +113,7 @@ public final class DocumentVersionNavs {
     public static Function<VecDocumentVersion, VecPlaceableElementRole> placeableElementRoleBy(
             final String specificationValue,
             final String occurrenceOrUsageId) {
-        return dv -> SpecificationNavs.componentsBy(specificationValue).apply(dv)
+        return documentVersion -> SpecificationNavs.componentsBy(specificationValue).apply(documentVersion)
                 .stream()
                 .filter(c -> c.getIdentification().equals(occurrenceOrUsageId))
                 .map(VecPartOccurrence::getRoles)
@@ -125,11 +125,11 @@ public final class DocumentVersionNavs {
 
     public static Function<VecDocumentVersion, VecPlacement> placementBy(final String specificationValue,
                                                                          final String occurrenceOrUsageId) {
-        return dv -> {
+        return documentVersion -> {
             final VecPlaceableElementRole role =
-                    placeableElementRoleBy(specificationValue, occurrenceOrUsageId).apply(dv);
+                    placeableElementRoleBy(specificationValue, occurrenceOrUsageId).apply(documentVersion);
 
-            return dv.getSpecificationsWithType(VecPlacementSpecification.class).stream()
+            return documentVersion.getSpecificationsWithType(VecPlacementSpecification.class).stream()
                     .map(VecPlacementSpecification::getPlacements)
                     .flatMap(Collection::stream)
                     .filter(p -> p.getPlacedElement().stream().anyMatch(r -> r.equals(role)))
@@ -138,8 +138,8 @@ public final class DocumentVersionNavs {
     }
 
     public static Function<VecDocumentVersion, VecGeometryNode2D> geometryNode2DBy(final VecNodeLocation location) {
-        return dv -> {
-            final List<VecGeometryNode2D> nodes = dv.getSpecificationWithType(VecBuildingBlockSpecification2D.class)
+        return documentVersion -> {
+            final List<VecGeometryNode2D> nodes = documentVersion.getSpecificationWithType(VecBuildingBlockSpecification2D.class)
                     .map(VecBuildingBlockSpecification2D::getGeometryNodes)
                     .orElseGet(Collections::emptyList);
             return getGeometryNode(nodes, location);
@@ -147,8 +147,8 @@ public final class DocumentVersionNavs {
     }
 
     public static Function<VecDocumentVersion, VecGeometryNode3D> geometryNode3DBy(final VecNodeLocation location) {
-        return dv -> {
-            final List<VecGeometryNode3D> nodes = dv.getSpecificationWithType(VecBuildingBlockSpecification3D.class)
+        return documentVersion -> {
+            final List<VecGeometryNode3D> nodes = documentVersion.getSpecificationWithType(VecBuildingBlockSpecification3D.class)
                     .map(VecBuildingBlockSpecification3D::getGeometryNodes)
                     .orElseGet(Collections::emptyList);
             return getGeometryNode(nodes, location);
@@ -157,8 +157,8 @@ public final class DocumentVersionNavs {
 
     public static Function<VecDocumentVersion, Optional<VecOccurrenceOrUsageViewItem2D>> viewItem2DBy(
             final String occurrenceOrUsageId) {
-        return dv -> {
-            final Stream<VecOccurrenceOrUsageViewItem2D> stream = dv
+        return documentVersion -> {
+            final Stream<VecOccurrenceOrUsageViewItem2D> stream = documentVersion
                     .getSpecificationsWithType(VecBuildingBlockSpecification2D.class)
                     .stream()
                     .map(VecBuildingBlockSpecification2D::getPlacedElementViewItems)
@@ -169,8 +169,8 @@ public final class DocumentVersionNavs {
 
     public static Function<VecDocumentVersion, Optional<VecOccurrenceOrUsageViewItem3D>> viewItem3DBy(
             final String occurrenceOrUsageId) {
-        return dv -> {
-            final Stream<VecOccurrenceOrUsageViewItem3D> stream = dv
+        return documentVersion -> {
+            final Stream<VecOccurrenceOrUsageViewItem3D> stream = documentVersion
                     .getSpecificationsWithType(VecBuildingBlockSpecification3D.class)
                     .stream()
                     .map(VecBuildingBlockSpecification3D::getPlacedElementViewItem3Ds)
@@ -181,17 +181,17 @@ public final class DocumentVersionNavs {
 
     public static Function<VecDocumentVersion, Optional<VecBuildingBlockSpecification2D>> buildingBlockSpecification2DBy(
             final String specificationId) {
-        return dv -> dv.getSpecificationWith(VecBuildingBlockSpecification2D.class, specificationId);
+        return documentVersion -> documentVersion.getSpecificationWith(VecBuildingBlockSpecification2D.class, specificationId);
     }
 
     public static Function<VecDocumentVersion, Optional<VecBuildingBlockSpecification3D>> buildingBlockSpecification3DBy(
             final String specificationId) {
-        return dv -> dv.getSpecificationWith(VecBuildingBlockSpecification3D.class, specificationId);
+        return documentVersion -> documentVersion.getSpecificationWith(VecBuildingBlockSpecification3D.class, specificationId);
     }
 
     public static Function<VecDocumentVersion, Optional<VecBuildingBlockPositioning2D>> positioning2DWith(
             final VecBuildingBlockSpecification2D buildingBlock) {
-        return dv -> dv.getSpecificationsWithType(VecHarnessDrawingSpecification2D.class).stream()
+        return documentVersion -> documentVersion.getSpecificationsWithType(VecHarnessDrawingSpecification2D.class).stream()
                 .map(VecHarnessDrawingSpecification2D::getBuildingBlockPositionings)
                 .flatMap(Collection::stream)
                 .filter(positioning -> buildingBlock.equals(positioning.getReferenced2DBuildingBlock()))
@@ -200,7 +200,7 @@ public final class DocumentVersionNavs {
 
     public static Function<VecDocumentVersion, Optional<VecBuildingBlockPositioning3D>> positioning3DWith(
             final VecBuildingBlockSpecification3D buildingBlock) {
-        return dv -> dv.getSpecificationsWithType(VecHarnessGeometrySpecification3D.class).stream()
+        return documentVersion -> documentVersion.getSpecificationsWithType(VecHarnessGeometrySpecification3D.class).stream()
                 .map(VecHarnessGeometrySpecification3D::getBuildingBlockPositionings)
                 .flatMap(Collection::stream)
                 .filter(positioning -> buildingBlock.equals(positioning.getReferenced3DBuildingBlock()))

--- a/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/DocumentVersionNavs.java
+++ b/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/DocumentVersionNavs.java
@@ -112,6 +112,33 @@ public final class DocumentVersionNavs {
                 .collect(Collectors.toList());
     }
 
+    public static Function<VecDocumentVersion, VecPlaceableElementRole> placeableElementRoleBy(
+            final String specificationValue,
+            final String occurrenceOrUsageId) {
+        return dv -> SpecificationNavs.componentsBy(specificationValue).apply(dv)
+                .stream()
+                .filter(c -> c.getIdentification().equals(occurrenceOrUsageId))
+                .map(VecPartOccurrence::getRoles)
+                .flatMap(Collection::stream)
+                .filter(VecPlaceableElementRole.class::isInstance)
+                .map(VecPlaceableElementRole.class::cast)
+                .collect(StreamUtils.findOne());
+    }
+
+    public static Function<VecDocumentVersion, VecPlacement> placementBy(final String specificationValue,
+                                                                         final String occurrenceOrUsageId) {
+        return dv -> {
+            final VecPlaceableElementRole role =
+                    placeableElementRoleBy(specificationValue, occurrenceOrUsageId).apply(dv);
+
+            return dv.getSpecificationsWithType(VecPlacementSpecification.class).stream()
+                    .map(VecPlacementSpecification::getPlacements)
+                    .flatMap(Collection::stream)
+                    .filter(p -> p.getPlacedElement().stream().anyMatch(r -> r.equals(role)))
+                    .collect(StreamUtils.findOne());
+        };
+    }
+
     public static Function<VecDocumentVersion, VecGeometryNode2D> geometryNode2DBy(final VecNodeLocation location) {
         return dv -> {
             final List<VecGeometryNode2D> nodes = dv.getSpecificationWithType(VecBuildingBlockSpecification2D.class)

--- a/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/DocumentVersionNavs.java
+++ b/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/DocumentVersionNavs.java
@@ -167,7 +167,7 @@ public final class DocumentVersionNavs {
         return dv -> dv.getSpecificationsWithType(VecHarnessDrawingSpecification2D.class).stream()
                 .map(VecHarnessDrawingSpecification2D::getBuildingBlockPositionings)
                 .flatMap(Collection::stream)
-                .filter(positioning -> positioning.getReferenced2DBuildingBlock() == buildingBlock)
+                .filter(positioning -> buildingBlock.equals(positioning.getReferenced2DBuildingBlock()))
                 .collect(StreamUtils.findOneOrNone());
     }
 
@@ -176,7 +176,7 @@ public final class DocumentVersionNavs {
         return dv -> dv.getSpecificationsWithType(VecHarnessGeometrySpecification3D.class).stream()
                 .map(VecHarnessGeometrySpecification3D::getBuildingBlockPositionings)
                 .flatMap(Collection::stream)
-                .filter(positioning -> positioning.getReferenced3DBuildingBlock() == buildingBlock)
+                .filter(positioning -> buildingBlock.equals(positioning.getReferenced3DBuildingBlock()))
                 .collect(StreamUtils.findOneOrNone());
     }
 
@@ -194,7 +194,7 @@ public final class DocumentVersionNavs {
                         .collect(StreamUtils.findOne())
                         .getIdentification()
                         .equals(occurrenceOrUsageId))
-                .findAny();
+                .collect(StreamUtils.findOneOrNone());
     }
 
 }

--- a/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/DocumentVersionNavs.java
+++ b/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/DocumentVersionNavs.java
@@ -139,7 +139,8 @@ public final class DocumentVersionNavs {
 
     public static Function<VecDocumentVersion, VecGeometryNode2D> geometryNode2DBy(final VecNodeLocation location) {
         return documentVersion -> {
-            final List<VecGeometryNode2D> nodes = documentVersion.getSpecificationWithType(VecBuildingBlockSpecification2D.class)
+            final List<VecGeometryNode2D> nodes = documentVersion
+                    .getSpecificationWithType(VecBuildingBlockSpecification2D.class)
                     .map(VecBuildingBlockSpecification2D::getGeometryNodes)
                     .orElseGet(Collections::emptyList);
             return getGeometryNode(nodes, location);
@@ -148,7 +149,8 @@ public final class DocumentVersionNavs {
 
     public static Function<VecDocumentVersion, VecGeometryNode3D> geometryNode3DBy(final VecNodeLocation location) {
         return documentVersion -> {
-            final List<VecGeometryNode3D> nodes = documentVersion.getSpecificationWithType(VecBuildingBlockSpecification3D.class)
+            final List<VecGeometryNode3D> nodes = documentVersion
+                    .getSpecificationWithType(VecBuildingBlockSpecification3D.class)
                     .map(VecBuildingBlockSpecification3D::getGeometryNodes)
                     .orElseGet(Collections::emptyList);
             return getGeometryNode(nodes, location);
@@ -181,17 +183,20 @@ public final class DocumentVersionNavs {
 
     public static Function<VecDocumentVersion, Optional<VecBuildingBlockSpecification2D>> buildingBlockSpecification2DBy(
             final String specificationId) {
-        return documentVersion -> documentVersion.getSpecificationWith(VecBuildingBlockSpecification2D.class, specificationId);
+        return documentVersion -> documentVersion
+                .getSpecificationWith(VecBuildingBlockSpecification2D.class, specificationId);
     }
 
     public static Function<VecDocumentVersion, Optional<VecBuildingBlockSpecification3D>> buildingBlockSpecification3DBy(
             final String specificationId) {
-        return documentVersion -> documentVersion.getSpecificationWith(VecBuildingBlockSpecification3D.class, specificationId);
+        return documentVersion -> documentVersion
+                .getSpecificationWith(VecBuildingBlockSpecification3D.class, specificationId);
     }
 
     public static Function<VecDocumentVersion, Optional<VecBuildingBlockPositioning2D>> positioning2DWith(
             final VecBuildingBlockSpecification2D buildingBlock) {
-        return documentVersion -> documentVersion.getSpecificationsWithType(VecHarnessDrawingSpecification2D.class).stream()
+        return documentVersion -> documentVersion
+                .getSpecificationsWithType(VecHarnessDrawingSpecification2D.class).stream()
                 .map(VecHarnessDrawingSpecification2D::getBuildingBlockPositionings)
                 .flatMap(Collection::stream)
                 .filter(positioning -> buildingBlock.equals(positioning.getReferenced2DBuildingBlock()))
@@ -200,7 +205,8 @@ public final class DocumentVersionNavs {
 
     public static Function<VecDocumentVersion, Optional<VecBuildingBlockPositioning3D>> positioning3DWith(
             final VecBuildingBlockSpecification3D buildingBlock) {
-        return documentVersion -> documentVersion.getSpecificationsWithType(VecHarnessGeometrySpecification3D.class).stream()
+        return documentVersion -> documentVersion
+                .getSpecificationsWithType(VecHarnessGeometrySpecification3D.class).stream()
                 .map(VecHarnessGeometrySpecification3D::getBuildingBlockPositionings)
                 .flatMap(Collection::stream)
                 .filter(positioning -> buildingBlock.equals(positioning.getReferenced3DBuildingBlock()))

--- a/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/DocumentVersionNavs.java
+++ b/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/DocumentVersionNavs.java
@@ -111,9 +111,9 @@ public final class DocumentVersionNavs {
     }
 
     public static Function<VecDocumentVersion, VecPlaceableElementRole> placeableElementRoleBy(
-            final String specificationValue,
+            final String compositionSpecificationId,
             final String occurrenceOrUsageId) {
-        return documentVersion -> SpecificationNavs.componentsBy(specificationValue).apply(documentVersion)
+        return documentVersion -> SpecificationNavs.componentsBy(compositionSpecificationId).apply(documentVersion)
                 .stream()
                 .filter(c -> c.getIdentification().equals(occurrenceOrUsageId))
                 .map(VecPartOccurrence::getRoles)
@@ -123,11 +123,11 @@ public final class DocumentVersionNavs {
                 .collect(StreamUtils.findOne());
     }
 
-    public static Function<VecDocumentVersion, VecPlacement> placementBy(final String specificationValue,
+    public static Function<VecDocumentVersion, VecPlacement> placementBy(final String compositionSpecificationId,
                                                                          final String occurrenceOrUsageId) {
         return documentVersion -> {
             final VecPlaceableElementRole role =
-                    placeableElementRoleBy(specificationValue, occurrenceOrUsageId).apply(documentVersion);
+                    placeableElementRoleBy(compositionSpecificationId, occurrenceOrUsageId).apply(documentVersion);
 
             return documentVersion.getSpecificationsWithType(VecPlacementSpecification.class).stream()
                     .map(VecPlacementSpecification::getPlacements)

--- a/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/PlacementNavs.java
+++ b/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/PlacementNavs.java
@@ -10,10 +10,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,8 +25,8 @@
  */
 package com.foursoft.harness.vec.v12x.navigations;
 
-import com.foursoft.harness.vec.v12x.*;
 import com.foursoft.harness.vec.common.util.StreamUtils;
+import com.foursoft.harness.vec.v12x.*;
 
 import java.util.Collections;
 import java.util.List;
@@ -75,6 +75,20 @@ public final class PlacementNavs {
                         .flatMap(List::stream)
                         .collect(Collectors.toList()))
                 .orElseGet(Collections::emptyList);
+    }
+
+    public static <T extends VecLocation> Function<VecOnWayPlacement, List<T>> locationsWith(
+            final Class<T> locationType) {
+        return placement ->
+                getLocationsByType(Stream.of(placement.getStartLocation(), placement.getEndLocation()), locationType)
+                        .collect(Collectors.toList());
+    }
+
+    private static <T extends VecLocation> Stream<T> getLocationsByType(final Stream<VecLocation> locations,
+                                                                        final Class<T> locationType) {
+        return locations
+                .filter(locationType::isInstance)
+                .map(locationType::cast);
     }
 
 }

--- a/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/SpecificationNavs.java
+++ b/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/SpecificationNavs.java
@@ -93,13 +93,13 @@ public final class SpecificationNavs {
      * Gets the {@link VecCompositionSpecification} with the given specification value and
      * gets their {@link VecCompositionSpecification#getComponents() components}.
      *
-     * @param specificationValue Value the specification has to have.
+     * @param compositionSpecificationId Id the {@link VecCompositionSpecification} has to have.
      * @return A possibly-empty list of Components.
      */
     public static Function<HasSpecifications<VecSpecification>, List<VecPartOccurrence>> componentsBy(
-            final String specificationValue) {
+            final String compositionSpecificationId) {
         return specifications -> specifications
-                .getSpecificationWith(VecCompositionSpecification.class, specificationValue)
+                .getSpecificationWith(VecCompositionSpecification.class, compositionSpecificationId)
                 .map(VecCompositionSpecification::getComponents)
                 .orElseGet(Collections::emptyList);
     }

--- a/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/SpecificationNavs.java
+++ b/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/SpecificationNavs.java
@@ -10,10 +10,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,9 +25,10 @@
  */
 package com.foursoft.harness.vec.v12x.navigations;
 
-import com.foursoft.harness.vec.v12x.*;
 import com.foursoft.harness.vec.common.HasSpecifications;
 import com.foursoft.harness.vec.common.annotations.RequiresBackReferences;
+import com.foursoft.harness.vec.common.util.StreamUtils;
+import com.foursoft.harness.vec.v12x.*;
 
 import java.util.Collection;
 import java.util.function.Function;
@@ -41,7 +42,6 @@ public final class SpecificationNavs {
     private SpecificationNavs() {
         // hide default constructor
     }
-
 
     @RequiresBackReferences
     public static Function<VecSpecification, String> parentDocumentNumber() {
@@ -71,6 +71,32 @@ public final class SpecificationNavs {
                 return sheetOrChapter.getParentDocumentVersion();
             }
         };
+    }
+
+    public static Function<VecBuildingBlockSpecification2D, VecGeometrySegment2D> geometrySegment2DBy(
+            final String segmentId) {
+        return specification -> specification.getGeometrySegments().stream()
+                .filter(segment -> segment.getIdentification().equals(segmentId))
+                .collect(StreamUtils.findOne());
+    }
+
+    public static Function<VecBuildingBlockSpecification3D, VecGeometrySegment3D> geometrySegment3DBy(
+            final String segmentId) {
+        return specification -> specification.getGeometrySegments().stream()
+                .filter(segment -> segment.getIdentification().equals(segmentId))
+                .collect(StreamUtils.findOne());
+    }
+
+    public static Function<VecBuildingBlockSpecification2D, VecGeometryNode2D> geometryNode2DBy(final String nodeId) {
+        return specification -> specification.getGeometryNodes().stream()
+                .filter(node -> node.getIdentification().equals(nodeId))
+                .collect(StreamUtils.findOne());
+    }
+
+    public static Function<VecBuildingBlockSpecification3D, VecGeometryNode3D> geometryNode3DBy(final String nodeId) {
+        return specification -> specification.getGeometryNodes().stream()
+                .filter(node -> node.getIdentification().equals(nodeId))
+                .collect(StreamUtils.findOne());
     }
 
 }

--- a/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/SpecificationNavs.java
+++ b/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/SpecificationNavs.java
@@ -64,13 +64,14 @@ public final class SpecificationNavs {
         };
     }
 
-    public static Function<HasSpecifications<VecSpecification>, Stream<VecOccurrenceOrUsage>> allOccurrenceOrUsages() {
+    public static Function<HasSpecifications<VecSpecification>, List<VecOccurrenceOrUsage>> allOccurrenceOrUsages() {
         return specifications -> Stream.concat(
-                components().apply(specifications).stream(),
-                specifications.getSpecificationsWithType(VecPartUsageSpecification.class)
-                        .stream()
-                        .map(VecPartUsageSpecification::getPartUsages)
-                        .flatMap(Collection::stream));
+                        components().apply(specifications).stream(),
+                        specifications.getSpecificationsWithType(VecPartUsageSpecification.class)
+                                .stream()
+                                .map(VecPartUsageSpecification::getPartUsages)
+                                .flatMap(Collection::stream))
+                .collect(Collectors.toList());
     }
 
     /**

--- a/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/SpecificationNavs.java
+++ b/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/SpecificationNavs.java
@@ -65,9 +65,9 @@ public final class SpecificationNavs {
     }
 
     public static Function<HasSpecifications<VecSpecification>, Stream<VecOccurrenceOrUsage>> allOccurrenceOrUsages() {
-        return hasSpecifications -> Stream.concat(
-                components().apply(hasSpecifications).stream(),
-                hasSpecifications.getSpecificationsWithType(VecPartUsageSpecification.class)
+        return specifications -> Stream.concat(
+                components().apply(specifications).stream(),
+                specifications.getSpecificationsWithType(VecPartUsageSpecification.class)
                         .stream()
                         .map(VecPartUsageSpecification::getPartUsages)
                         .flatMap(Collection::stream));
@@ -80,7 +80,7 @@ public final class SpecificationNavs {
      * @return A possibly-empty list of Components.
      */
     public static Function<HasSpecifications<VecSpecification>, List<VecPartOccurrence>> components() {
-        return hasSpecifications -> hasSpecifications
+        return specifications -> specifications
                 .getSpecificationsWithType(VecCompositionSpecification.class)
                 .stream()
                 .map(VecCompositionSpecification::getComponents)
@@ -97,7 +97,7 @@ public final class SpecificationNavs {
      */
     public static Function<HasSpecifications<VecSpecification>, List<VecPartOccurrence>> componentsBy(
             final String specificationValue) {
-        return hasSpecifications -> hasSpecifications
+        return specifications -> specifications
                 .getSpecificationWith(VecCompositionSpecification.class, specificationValue)
                 .map(VecCompositionSpecification::getComponents)
                 .orElseGet(Collections::emptyList);

--- a/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/SpecificationNavs.java
+++ b/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/SpecificationNavs.java
@@ -31,6 +31,8 @@ import com.foursoft.harness.vec.common.util.StreamUtils;
 import com.foursoft.harness.vec.v12x.*;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -58,6 +60,21 @@ public final class SpecificationNavs {
                         .stream()
                         .map(VecPartUsageSpecification::getPartUsages)
                         .flatMap(Collection::stream));
+    }
+
+    /**
+     * Gets the {@link VecCompositionSpecification} with the given specification value and
+     * gets their {@link VecCompositionSpecification#getComponents() components}.
+     *
+     * @param specificationValue Value the specification has to have.
+     * @return A possibly-empty list of Components.
+     */
+    public static Function<HasSpecifications<VecSpecification>, List<VecPartOccurrence>> componentsBy(
+            final String specificationValue) {
+        return hasSpecifications -> hasSpecifications
+                .getSpecificationWith(VecCompositionSpecification.class, specificationValue)
+                .map(VecCompositionSpecification::getComponents)
+                .orElseGet(Collections::emptyList);
     }
 
     @RequiresBackReferences


### PR DESCRIPTION
## Pull Request

- [x] I have checked for similar PRs.
- [x] I have read the [contributing guidelines](https://github.com/4Soft-de/vec-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [x] Code
- [x] Documentation
- [ ] Other: 

### Description

Added 17 new navigation methods for the `VecDocumentVersion` (`DocumentVersionNavs`), `VecOnWayPlacement` (`PlacementNavs`) and `VecSpecification` / `HasSpecifications` (`SpecificationNavs`).

The navigation methods are about
- placeable element roles,
- placements,
- geometry nodes,
- view items,
- building blocks,
- positionings,
- locations,
- components and
- geometry segments.

### Breaking changes

This includes a breaking change chaning a signature of the `SpecificationNavs`:
```diff
- public static Function<HasSpecifications<VecSpecification>, Stream<VecOccurrenceOrUsage>> allOccurrenceOrUsages()
+ public static Function<HasSpecifications<VecSpecification>, List<VecOccurrenceOrUsage>> allOccurrenceOrUsages()
```