### PR TITLE
Added navigation methods to get the parent `VecDocumentVersion` of a `VecPartUsage`

### DIFF
--- a/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/PartOccurrenceOrUsageNavs.java
+++ b/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/PartOccurrenceOrUsageNavs.java
@@ -49,10 +49,7 @@ public final class PartOccurrenceOrUsageNavs {
 
     @RequiresBackReferences
     public static Function<VecPartUsage, String> parentDocumentNumberOfUsage() {
-        return usage -> {
-            final VecPartUsageSpecification partUsageSpec = usage.getParentPartUsageSpecification();
-            return SpecificationNavs.parentDocumentNumber().apply(partUsageSpec);
-        };
+        return usage -> parentDocumentVersionOfUsage().apply(usage).getDocumentNumber();
     }
 
     @RequiresBackReferences
@@ -67,10 +64,7 @@ public final class PartOccurrenceOrUsageNavs {
 
     @RequiresBackReferences
     public static Function<VecPartOccurrence, String> parentDocumentNumberOfOccurrence() {
-        return occurrence -> {
-            final VecCompositionSpecification compSpec = occurrence.getParentCompositionSpecification();
-            return SpecificationNavs.parentDocumentNumber().apply(compSpec);
-        };
+        return occurrence -> parentDocumentVersionOfOccurrence().apply(occurrence).getDocumentNumber();
     }
 
     public static Function<VecPartOccurrence, Optional<String>> partNumber() {
@@ -143,12 +137,7 @@ public final class PartOccurrenceOrUsageNavs {
 
     @RequiresBackReferences
     public static Function<VecOccurrenceOrUsage, String> parentDocumentNumber() {
-        return occurrenceOrUsage -> {
-            if (occurrenceOrUsage instanceof VecPartOccurrence) {
-                return parentDocumentNumberOfOccurrence().apply((VecPartOccurrence) occurrenceOrUsage);
-            }
-            return parentDocumentNumberOfUsage().apply((VecPartUsage) occurrenceOrUsage);
-        };
+        return occurrenceOrUsage -> parentDocumentVersion().apply(occurrenceOrUsage).getDocumentNumber();
     }
 
     @RequiresBackReferences

--- a/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/PartOccurrenceOrUsageNavs.java
+++ b/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/PartOccurrenceOrUsageNavs.java
@@ -55,6 +55,14 @@ public final class PartOccurrenceOrUsageNavs {
         };
     }
 
+    @RequiresBackReferences
+    public static Function<VecPartUsage, VecDocumentVersion> parentDocumentVersionOfUsage() {
+        return usage -> {
+            final VecPartUsageSpecification partUsageSpec = usage.getParentPartUsageSpecification();
+            return SpecificationNavs.parentDocumentVersion().apply(partUsageSpec);
+        };
+    }
+
     // VecPartOccurrence
 
     @RequiresBackReferences
@@ -101,7 +109,7 @@ public final class PartOccurrenceOrUsageNavs {
      * @return The parent VecDocumentVersion of a VecPartOccurrence.
      */
     @RequiresBackReferences
-    public static Function<VecPartOccurrence, VecDocumentVersion> parentDocumentVersion() {
+    public static Function<VecPartOccurrence, VecDocumentVersion> parentDocumentVersionOfOccurrence() {
         return occurrence -> {
 
             final VecCompositionSpecification parentCompositionSpecification =
@@ -140,6 +148,16 @@ public final class PartOccurrenceOrUsageNavs {
                 return parentDocumentNumberOfOccurrence().apply((VecPartOccurrence) occurrenceOrUsage);
             }
             return parentDocumentNumberOfUsage().apply((VecPartUsage) occurrenceOrUsage);
+        };
+    }
+
+    @RequiresBackReferences
+    public static Function<VecOccurrenceOrUsage, VecDocumentVersion> parentDocumentVersion() {
+        return occurrenceOrUsage -> {
+            if (occurrenceOrUsage instanceof VecPartOccurrence) {
+                return parentDocumentVersionOfOccurrence().apply((VecPartOccurrence) occurrenceOrUsage);
+            }
+            return parentDocumentVersionOfUsage().apply((VecPartUsage) occurrenceOrUsage);
         };
     }
 

--- a/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/PartOccurrenceOrUsageNavs.java
+++ b/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/PartOccurrenceOrUsageNavs.java
@@ -10,10 +10,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,11 +25,11 @@
  */
 package com.foursoft.harness.vec.v12x.navigations;
 
-import com.foursoft.harness.vec.v12x.*;
-import com.foursoft.harness.vec.v12x.visitor.ReferencedNodeLocationVisitor;
 import com.foursoft.harness.vec.common.annotations.RequiresBackReferences;
 import com.foursoft.harness.vec.common.util.StreamUtils;
 import com.foursoft.harness.vec.common.util.StringUtils;
+import com.foursoft.harness.vec.v12x.*;
+import com.foursoft.harness.vec.v12x.visitor.ReferencedNodeLocationVisitor;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -45,10 +45,20 @@ public final class PartOccurrenceOrUsageNavs {
         // hide default constructor
     }
 
+    // VecPartUsage
+
+    @RequiresBackReferences
+    public static Function<VecPartUsage, String> parentDocumentNumberOfUsage() {
+        return usage -> {
+            final VecPartUsageSpecification partUsageSpec = usage.getParentPartUsageSpecification();
+            return SpecificationNavs.parentDocumentNumber().apply(partUsageSpec);
+        };
+    }
+
     // VecPartOccurrence
 
     @RequiresBackReferences
-    public static Function<VecPartOccurrence, String> parentDocumentNumber() {
+    public static Function<VecPartOccurrence, String> parentDocumentNumberOfOccurrence() {
         return occurrence -> {
             final VecCompositionSpecification compSpec = occurrence.getParentCompositionSpecification();
             return SpecificationNavs.parentDocumentNumber().apply(compSpec);
@@ -122,6 +132,16 @@ public final class PartOccurrenceOrUsageNavs {
     }
 
     // VecOccurrenceOrUsage
+
+    @RequiresBackReferences
+    public static Function<VecOccurrenceOrUsage, String> parentDocumentNumber() {
+        return occurrenceOrUsage -> {
+            if (occurrenceOrUsage instanceof VecPartOccurrence) {
+                return parentDocumentNumberOfOccurrence().apply((VecPartOccurrence) occurrenceOrUsage);
+            }
+            return parentDocumentNumberOfUsage().apply((VecPartUsage) occurrenceOrUsage);
+        };
+    }
 
     public static BiFunction<VecOccurrenceOrUsage, VecDocumentVersion, Optional<VecTopologyNode>> findNodeOfComponent() {
         return (component, documentVersion) -> component.getRoleWithType(VecPlaceableElementRole.class)

--- a/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/VecNavs.java
+++ b/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/VecNavs.java
@@ -10,10 +10,10 @@
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,8 +25,11 @@
  */
 package com.foursoft.harness.vec.v12x.navigations;
 
-import com.foursoft.harness.vec.v12x.*;
 import com.foursoft.harness.vec.common.annotations.RequiresBackReferences;
+import com.foursoft.harness.vec.v12x.VecDocumentVersion;
+import com.foursoft.harness.vec.v12x.VecExtendableElement;
+import com.foursoft.harness.vec.v12x.VecOccurrenceOrUsage;
+import com.foursoft.harness.vec.v12x.VecRole;
 
 import java.util.List;
 import java.util.function.Function;
@@ -51,13 +54,7 @@ public final class VecNavs {
     public static Function<VecRole, VecDocumentVersion> parentDocumentVersion() {
         return role -> {
             final VecOccurrenceOrUsage parentOccurrenceOrUsage = role.getParentOccurrenceOrUsage();
-            if (parentOccurrenceOrUsage instanceof VecPartOccurrence) {
-                return PartOccurrenceOrUsageNavs.parentDocumentVersion().apply((VecPartOccurrence) parentOccurrenceOrUsage);
-            } else {
-                final VecPartUsageSpecification parentPartUsageSpecification =
-                        ((VecPartUsage) parentOccurrenceOrUsage).getParentPartUsageSpecification();
-                return SpecificationNavs.parentDocumentVersion().apply(parentPartUsageSpecification);
-            }
+            return PartOccurrenceOrUsageNavs.parentDocumentVersion().apply(parentOccurrenceOrUsage);
         };
     }
 


### PR DESCRIPTION
## Pull Request

- [x] I have checked for similar PRs.
- [x] I have read the [contributing guidelines](https://github.com/4Soft-de/vec-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [x] Code
- [ ] Documentation
- [ ] Other: 

### Description

Currently, the `PartOccurrenceOrUsageNavs` only offers a methods to get the parent Document Number and the parent `VecDocumentVersion` of a `VecPartOccurrence`, not of a `VecPartUsage`.

This PR adds those methods for the `VecPartUsage`. With that, general methods for the `VecOccurrenceOrUsage` were added too so no casting is required.

Existing methods for the `VecPartOccurrence` were renamed but they won't affect end users due to the added methods for the `VecOccurrenceOrUsage`.

```java
// Before
PartOccurrenceOrUsageNavs.parentDocumentNumber().apply(partOccurrence);  // Takes a VecPartOccurrence.

// Now
PartOccurrenceOrUsageNavs.parentDocumentNumberOfOccurrence().apply(partOccurrence);  // Takes a VecPartOccurrence.
PartOccurrenceOrUsageNavs.parentDocumentNumber().apply(partOccurrence);  // Takes both, VecPartOccurrence and VecPartUsage.
```