### PR TITLE
Not using `StreamUtils.findOne()` when it's not safe

### DIFF
--- a/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/DocumentVersionNavs.java
+++ b/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/DocumentVersionNavs.java
@@ -120,7 +120,7 @@ public final class DocumentVersionNavs {
                 .flatMap(Collection::stream)
                 .filter(VecPlaceableElementRole.class::isInstance)
                 .map(VecPlaceableElementRole.class::cast)
-                .collect(StreamUtils.findOne());
+                .collect(StreamUtils.findOneOrNone()).orElse(null);
     }
 
     public static Function<VecDocumentVersion, VecPlacement> placementBy(final String compositionSpecificationId,
@@ -133,7 +133,7 @@ public final class DocumentVersionNavs {
                     .map(VecPlacementSpecification::getPlacements)
                     .flatMap(Collection::stream)
                     .filter(p -> p.getPlacedElement().stream().anyMatch(r -> r.equals(role)))
-                    .collect(StreamUtils.findOne());
+                    .collect(StreamUtils.findOneOrNone()).orElse(null);
         };
     }
 
@@ -217,16 +217,17 @@ public final class DocumentVersionNavs {
                                                                  final VecNodeLocation location) {
         return nodes.stream()
                 .filter(node -> node.getReferenceNode().equals(location.getReferencedNode()))
-                .collect(StreamUtils.findOne());
+                .collect(StreamUtils.findOneOrNone()).orElse(null);
     }
 
     private static <T extends HasOccurrenceOrUsages> Optional<T> getViewItem(final Stream<T> stream,
                                                                              final String occurrenceOrUsageId) {
         return stream
                 .filter(item -> item.getOccurrenceOrUsage().stream()
-                        .collect(StreamUtils.findOne())
-                        .getIdentification()
-                        .equals(occurrenceOrUsageId))
+                        .collect(StreamUtils.findOneOrNone())
+                        .map(VecOccurrenceOrUsage::getIdentification)
+                        .map(id -> id.equals(occurrenceOrUsageId))
+                        .orElse(false))
                 .collect(StreamUtils.findOneOrNone());
     }
 

--- a/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/SpecificationNavs.java
+++ b/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/SpecificationNavs.java
@@ -108,26 +108,26 @@ public final class SpecificationNavs {
             final String segmentId) {
         return specification -> specification.getGeometrySegments().stream()
                 .filter(segment -> segment.getIdentification().equals(segmentId))
-                .collect(StreamUtils.findOne());
+                .collect(StreamUtils.findOneOrNone()).orElse(null);
     }
 
     public static Function<VecBuildingBlockSpecification3D, VecGeometrySegment3D> geometrySegment3dBy(
             final String segmentId) {
         return specification -> specification.getGeometrySegments().stream()
                 .filter(segment -> segment.getIdentification().equals(segmentId))
-                .collect(StreamUtils.findOne());
+                .collect(StreamUtils.findOneOrNone()).orElse(null);
     }
 
     public static Function<VecBuildingBlockSpecification2D, VecGeometryNode2D> geometryNode2dBy(final String nodeId) {
         return specification -> specification.getGeometryNodes().stream()
                 .filter(node -> node.getIdentification().equals(nodeId))
-                .collect(StreamUtils.findOne());
+                .collect(StreamUtils.findOneOrNone()).orElse(null);
     }
 
     public static Function<VecBuildingBlockSpecification3D, VecGeometryNode3D> geometryNode3dBy(final String nodeId) {
         return specification -> specification.getGeometryNodes().stream()
                 .filter(node -> node.getIdentification().equals(nodeId))
-                .collect(StreamUtils.findOne());
+                .collect(StreamUtils.findOneOrNone()).orElse(null);
     }
 
 }

--- a/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/SpecificationNavs.java
+++ b/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/SpecificationNavs.java
@@ -25,6 +25,7 @@
  */
 package com.foursoft.harness.vec.v12x.navigations;
 
+import com.foursoft.harness.vec.common.HasIdentification;
 import com.foursoft.harness.vec.common.HasSpecifications;
 import com.foursoft.harness.vec.common.annotations.RequiresBackReferences;
 import com.foursoft.harness.vec.common.util.StreamUtils;
@@ -106,27 +107,25 @@ public final class SpecificationNavs {
 
     public static Function<VecBuildingBlockSpecification2D, VecGeometrySegment2D> geometrySegment2dBy(
             final String segmentId) {
-        return specification -> specification.getGeometrySegments().stream()
-                .filter(segment -> segment.getIdentification().equals(segmentId))
-                .collect(StreamUtils.findOneOrNone()).orElse(null);
+        return specification -> findElementById(specification.getGeometrySegments(), segmentId);
     }
 
     public static Function<VecBuildingBlockSpecification3D, VecGeometrySegment3D> geometrySegment3dBy(
             final String segmentId) {
-        return specification -> specification.getGeometrySegments().stream()
-                .filter(segment -> segment.getIdentification().equals(segmentId))
-                .collect(StreamUtils.findOneOrNone()).orElse(null);
+        return specification -> findElementById(specification.getGeometrySegments(), segmentId);
     }
 
     public static Function<VecBuildingBlockSpecification2D, VecGeometryNode2D> geometryNode2dBy(final String nodeId) {
-        return specification -> specification.getGeometryNodes().stream()
-                .filter(node -> node.getIdentification().equals(nodeId))
-                .collect(StreamUtils.findOneOrNone()).orElse(null);
+        return specification -> findElementById(specification.getGeometryNodes(), nodeId);
     }
 
     public static Function<VecBuildingBlockSpecification3D, VecGeometryNode3D> geometryNode3dBy(final String nodeId) {
-        return specification -> specification.getGeometryNodes().stream()
-                .filter(node -> node.getIdentification().equals(nodeId))
+        return specification -> findElementById(specification.getGeometryNodes(), nodeId);
+    }
+
+    private static <T extends HasIdentification> T findElementById(final List<T> elements, final String id) {
+        return elements.stream()
+                .filter(element -> element.getIdentification().equals(id))
                 .collect(StreamUtils.findOneOrNone()).orElse(null);
     }
 


### PR DESCRIPTION
## Pull Request

- [x] I have checked for similar PRs.
- [x] I have read the [contributing guidelines](https://github.com/4Soft-de/vec-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [x] Code
- [ ] Documentation
- [ ] Other: 

Closes: #85 

### Description

This PR replaces the usages of `StreamUtils.findOne()` with `StreamUtils.findOneOrNone() -> .orElse(null)`. It was done like this to avoid breaking changes.