### PR TITLE
Fixed another possible NPE in `DescriptionNavs#stringIn`

### DIFF
--- a/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/DescriptionNavs.java
+++ b/v12x/src/main/java/com/foursoft/harness/vec/v12x/navigations/DescriptionNavs.java
@@ -34,6 +34,7 @@ import com.foursoft.harness.vec.v12x.VecLocalizedTypedString;
 import com.foursoft.harness.vec.v12x.predicates.VecPredicates;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -86,9 +87,11 @@ public final class DescriptionNavs {
             }
 
             return localizedStrings.stream()
+                    .filter(Objects::nonNull)
                     .filter(d -> !(d instanceof VecLocalizedTypedString))
                     .filter(VecPredicates.isLanguageCode(vecLanguageCode))
                     .map(VecAbstractLocalizedString::getValue)
+                    .filter(Objects::nonNull)
                     .collect(StreamUtils.findOneOrNone());
         };
     }


### PR DESCRIPTION
## Pull Request

- [x] I have checked for similar PRs.
- [x] I have read the [contributing guidelines](https://github.com/4Soft-de/vec-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [x] Code
- [ ] Documentation
- [ ] Other: 

### Description

Since `localizedStrings` seems to be able to contain `null` elements, an NPE can still occurre after merging #102 when more than one element is in the list.

This MR adds `null`-filtering to prevent possible NPEs.