### PR TITLE
Add `HasVecVersion` interface 

### DIFF
--- a/common/src/main/java/com/foursoft/harness/vec/common/HasVecVersion.java
+++ b/common/src/main/java/com/foursoft/harness/vec/common/HasVecVersion.java
@@ -1,0 +1,39 @@
+/*-
+ * ========================LICENSE_START=================================
+ * vec-common
+ * %%
+ * Copyright (C) 2020 - 2022 4Soft GmbH
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * =========================LICENSE_END==================================
+ */
+package com.foursoft.harness.vec.common;
+
+/**
+ * Marker interface for classes which have a VEC Version. This should be implemented by all {@code VecContent}s.
+ */
+public interface HasVecVersion {
+
+    /**
+     * Gets the VEC Version.
+     * @return The VEC Version.
+     */
+    String getVecVersion();
+
+}

--- a/v113/src/main/resources/vec113/vec_1.1.3-ext.xjb
+++ b/v113/src/main/resources/vec113/vec_1.1.3-ext.xjb
@@ -65,4 +65,8 @@
         <inheritance:implements>com.foursoft.harness.vec.common.HasLocations&lt;com.foursoft.harness.vec.v113.VecLocation&gt;</inheritance:implements>
     </jxb:bindings>
 
+    <jxb:bindings multiple="true" node="//xs:complexType[.//xs:element[@name='VecVersion']]">
+        <inheritance:implements>com.foursoft.harness.vec.common.HasVecVersion</inheritance:implements>
+    </jxb:bindings>
+
 </jxb:bindings>

--- a/v12x/src/main/resources/vec122/vec_1.2.2-ext.xjb
+++ b/v12x/src/main/resources/vec122/vec_1.2.2-ext.xjb
@@ -65,4 +65,8 @@
         <inheritance:implements>com.foursoft.harness.vec.common.HasLocations&lt;com.foursoft.harness.vec.v12x.VecLocation&gt;</inheritance:implements>
     </jxb:bindings>
 
+    <jxb:bindings multiple="true" node="//xs:complexType[.//xs:element[@name='VecVersion']]">
+        <inheritance:implements>com.foursoft.harness.vec.common.HasVecVersion</inheritance:implements>
+    </jxb:bindings>
+
 </jxb:bindings>

--- a/v2x/src/main/resources/vec2/vec_2.0.0-ext.xjb
+++ b/v2x/src/main/resources/vec2/vec_2.0.0-ext.xjb
@@ -65,4 +65,8 @@
         <inheritance:implements>com.foursoft.harness.vec.common.HasLocations&lt;com.foursoft.harness.vec.v2x.VecLocation&gt;</inheritance:implements>
     </jxb:bindings>
 
+    <jxb:bindings multiple="true" node="//xs:complexType[.//xs:element[@name='VecVersion']]">
+        <inheritance:implements>com.foursoft.harness.vec.common.HasVecVersion</inheritance:implements>
+    </jxb:bindings>
+
 </jxb:bindings>


### PR DESCRIPTION
## Pull Request

- [x] I have checked for similar PRs.
- [x] I have read the [contributing guidelines](https://github.com/4Soft-de/vec-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [x] Code
- [ ] Documentation
- [x] Other: JAXB Binding Declaration

### Description

Adds a new interface `HasVecVersion` to have a common class for all `VecContent`s. Also updated the .xjb files to include that new interface.