### PR TITLE
Add two methods to `PartOccurrenceOrUsageNavs` related to `VecPrimaryPartType` and `VecPartOrUsageRelatedSpecification`

### DIFF
--- a/v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/PartOccurrenceOrUsageNavs.java
+++ b/v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/PartOccurrenceOrUsageNavs.java
@@ -31,7 +31,9 @@ import com.foursoft.harness.vec.common.util.StringUtils;
 import com.foursoft.harness.vec.v2x.*;
 import com.foursoft.harness.vec.v2x.visitor.ReferencedNodeLocationVisitor;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -93,6 +95,11 @@ public final class PartOccurrenceOrUsageNavs {
                             .map(VecPartUsage::getPrimaryPartUsageType)
                             .orElse(VecPrimaryPartType.OTHER);
         };
+    }
+
+    @RequiresBackReferences
+    public static Function<VecPartOccurrence, List<VecPartOrUsageRelatedSpecification>> partOrUsageRelatedSpecificationsOfOccurrence() {
+        return occurrence -> new ArrayList<>(occurrence.getPart().getRefPartOrUsageRelatedSpecification());
     }
 
     /**
@@ -179,6 +186,16 @@ public final class PartOccurrenceOrUsageNavs {
                 return primaryPartTypeOfOccurrence().apply((VecPartOccurrence) occurrenceOrUsage);
             }
             return ((VecPartUsage) occurrenceOrUsage).getPrimaryPartUsageType();
+        };
+    }
+
+    @RequiresBackReferences
+    public static Function<VecOccurrenceOrUsage, List<VecPartOrUsageRelatedSpecification>> partOrUsageRelatedSpecifications() {
+        return occurrenceOrUsage -> {
+            if (occurrenceOrUsage instanceof VecPartOccurrence) {
+                return partOrUsageRelatedSpecificationsOfOccurrence().apply((VecPartOccurrence) occurrenceOrUsage);
+            }
+            return ((VecPartUsage) occurrenceOrUsage).getPartOrUsageRelatedSpecification();
         };
     }
 

--- a/v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/PartOccurrenceOrUsageNavs.java
+++ b/v2x/src/main/java/com/foursoft/harness/vec/v2x/navigations/PartOccurrenceOrUsageNavs.java
@@ -81,7 +81,7 @@ public final class PartOccurrenceOrUsageNavs {
                 .map(StringUtils::collapseMultipleWhitespaces);
     }
 
-    public static Function<VecPartOccurrence, VecPrimaryPartType> primaryPartType() {
+    public static Function<VecPartOccurrence, VecPrimaryPartType> primaryPartTypeOfOccurrence() {
         return occurrence -> {
             final VecPartVersion partVersion = occurrence.getPart();
             return partVersion != null
@@ -171,6 +171,15 @@ public final class PartOccurrenceOrUsageNavs {
                 .flatMap(Collection::stream)
                 .map(location -> location.accept(visitor))
                 .collect(StreamUtils.findOneOrNone());
+    }
+
+    public static Function<VecOccurrenceOrUsage, VecPrimaryPartType> primaryPartType() {
+        return occurrenceOrUsage -> {
+            if (occurrenceOrUsage instanceof VecPartOccurrence) {
+                return primaryPartTypeOfOccurrence().apply((VecPartOccurrence) occurrenceOrUsage);
+            }
+            return ((VecPartUsage) occurrenceOrUsage).getPrimaryPartUsageType();
+        };
     }
 
     public static Function<VecOccurrenceOrUsage, Optional<VecPartOccurrence>> occurrence() {


### PR DESCRIPTION
## Pull Request

- [x] I have checked for similar PRs.
- [x] I have read the [contributing guidelines](https://github.com/4Soft-de/vec-model/blob/develop/.github/CONTRIBUTING.md).

### Changes

- [x] Code
- [ ] Documentation
- [ ] Other: 

### Description

Same changes as #115 but for the VEC 2.0.0 module.

Add two new navigation methods for `VecOccurrenceOrUsage`s. Also added one of them only for `VecPartOccurrence` for consistency.